### PR TITLE
Fix indentation error after quotes

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -6,8 +6,10 @@ from typing import Optional
 import jira2markdown
 from jira2markdown.elements import MarkupElements
 from jira2markdown.markup.lists import UnorderedList, OrderedList
+from jira2markdown.markup.text_effects import BlockQuote, Quote
 
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
+from markup.text_effects import TweakedBlockQuote, TweakedQuote
 
 @dataclass
 class Attachment(object):
@@ -203,6 +205,8 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}) -> str:
     elements = MarkupElements()
     elements.replace(UnorderedList, UnorderedTweakedList)
     elements.replace(OrderedList, OrderedTweakedList)
+    elements.replace(BlockQuote, TweakedBlockQuote)
+    elements.replace(Quote, TweakedQuote)
     text = jira2markdown.convert(text, elements=elements)
 
     # markup @ mentions with ``

--- a/migration/src/markup/text_effects.py
+++ b/migration/src/markup/text_effects.py
@@ -1,0 +1,51 @@
+import re
+
+from pyparsing import (
+    ParserElement,
+    ParseResults,
+    QuotedString,
+    StringEnd,
+    StringStart,
+    SkipTo,
+    Literal,
+    LineEnd,
+    Optional,
+    Combine,
+    White,
+    OneOrMore,
+    nums,
+    replaceWith,
+
+)
+
+from jira2markdown.markup.base import AbstractMarkup
+
+class TweakedBlockQuote(AbstractMarkup):
+    def action(self, tokens: ParseResults) -> str:
+        text = self.markup.transformString("\n".join([line.lstrip() for line in tokens[0].strip().splitlines()]))
+        # escape numbered list in quotes.
+        # e.g.,
+        #   {quote}
+        #   2. foo
+        #   5. bar
+        #   {quote}
+        # should be
+        #   > 2\\. foo
+        #   > 5\\. bar
+        pat_ordered_list = re.compile(r"((?<=^\d)||(?<=^\d\d))\.")
+        return "\n".join(["> " + re.sub(pat_ordered_list, '\.', line) for line in text.splitlines()]) + "\n"  # needs additional line feed at the end of quotation to preserve indentation
+
+    @property
+    def expr(self) -> ParserElement:
+        return QuotedString("{quote}", multiline=True).setParseAction(self.action)
+
+
+class TweakedQuote(AbstractMarkup):
+    is_inline_element = False
+
+    @property
+    def expr(self) -> ParserElement:
+        return ("\n" | StringStart()) + Combine(
+            Literal("bq. ").setParseAction(replaceWith("> "))
+            + SkipTo(LineEnd()) + LineEnd().setParseAction(replaceWith("\n\n")) # needs additional line feed at the end of quotation to preserve indentation
+        )


### PR DESCRIPTION
#1 

With the default `Quote` and `BlockQuote` implementation of `jira2markdown`, the following paragraph is mistakenly interpreted as also part of the quotation in markdown. An additional line feed `\n` should be inserted after every quote/quote block.

**bq. quote**

broken indent example:
![Screenshot from 2022-07-09 14-51-20](https://user-images.githubusercontent.com/1825333/178093546-cfeb3e0e-20eb-4c00-b7b2-449708ec79e1.png)

with this patch:
![Screenshot from 2022-07-09 14-56-23](https://user-images.githubusercontent.com/1825333/178093677-4c40d91b-9f2d-4d7e-ab49-7b4bf2acf60f.png)

**{quote} quote block**

broken indent example:
![Screenshot from 2022-07-09 14-58-20](https://user-images.githubusercontent.com/1825333/178093745-0df61545-2b0b-4d39-b453-e3d24f14bc3d.png)

with this patch:
![Screenshot from 2022-07-09 14-59-58](https://user-images.githubusercontent.com/1825333/178093795-e7241428-9716-4e92-9f0c-d0beb69869d2.png)

This also escapes numbered lists in block quotes so that the number is preserved.

error example (a block quote include a numbered list):
![Screenshot from 2022-07-09 15-01-58](https://user-images.githubusercontent.com/1825333/178093851-64a4d60e-f5c7-4938-a494-f8afccc29b98.png)

with this patch:
![Screenshot from 2022-07-09 15-03-15](https://user-images.githubusercontent.com/1825333/178093867-c401fbac-70a3-43fe-b662-642d294fd20a.png)



