### PR TITLE
Remove extra brackets in {{monospaced}}

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -6,10 +6,10 @@ from typing import Optional
 import jira2markdown
 from jira2markdown.elements import MarkupElements
 from jira2markdown.markup.lists import UnorderedList, OrderedList
-from jira2markdown.markup.text_effects import BlockQuote, Quote
+from jira2markdown.markup.text_effects import BlockQuote, Quote, Monospaced
 
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
-from markup.text_effects import TweakedBlockQuote, TweakedQuote
+from markup.text_effects import TweakedBlockQuote, TweakedQuote, TweakedMonospaced
 
 @dataclass
 class Attachment(object):
@@ -207,6 +207,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}) -> str:
     elements.replace(OrderedList, OrderedTweakedList)
     elements.replace(BlockQuote, TweakedBlockQuote)
     elements.replace(Quote, TweakedQuote)
+    elements.replace(Monospaced, TweakedMonospaced)
     text = jira2markdown.convert(text, elements=elements)
 
     # markup @ mentions with ``

--- a/migration/src/markup/text_effects.py
+++ b/migration/src/markup/text_effects.py
@@ -4,16 +4,11 @@ from pyparsing import (
     ParserElement,
     ParseResults,
     QuotedString,
-    StringEnd,
     StringStart,
     SkipTo,
     Literal,
     LineEnd,
-    Optional,
     Combine,
-    White,
-    OneOrMore,
-    nums,
     replaceWith,
 
 )
@@ -49,3 +44,16 @@ class TweakedQuote(AbstractMarkup):
             Literal("bq. ").setParseAction(replaceWith("> "))
             + SkipTo(LineEnd()) + LineEnd().setParseAction(replaceWith("\n\n")) # needs additional line feed at the end of quotation to preserve indentation
         )
+
+
+class TweakedMonospaced(AbstractMarkup):
+    def action(self, tokens: ParseResults) -> str:
+        # remove extra brackets in {{monospaced}}
+        # e.g. {{{}BooleanScorer{}}}
+        token = re.sub(r"^[{}]+", "", tokens[0])
+        token = re.sub(r"[{}]+$", "", token)
+        return f"`{token}`"
+
+    @property
+    def expr(self) -> ParserElement:
+        return QuotedString("{{", endQuoteChar="}}").setParseAction(self.action)


### PR DESCRIPTION
In `{{monospaced}}` markup, sometimes extra brackets are inserted for some reason.

e.g. `{{{}ExitableDirectoryReader{}}}`

Although This may not be a conversion error, the rendered result appears as an error and may interfere with smooth reading.
This quick-fix tries to eliminate undesirable brackets in monospace (inline code element) as far as possible, as Jira frontend seems to do so.

example with extra brackets:
![Screenshot from 2022-07-09 16-17-30](https://user-images.githubusercontent.com/1825333/178095948-ecd3a563-6545-4a49-ab16-1d9618ccc2bd.png)

with this patch:
![Screenshot from 2022-07-09 16-17-52](https://user-images.githubusercontent.com/1825333/178095961-13762dbb-deb8-446e-8c86-e4fd69fb976d.png)
