### PR TITLE
Insert line break before ruler (dashes)

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -7,9 +7,12 @@ import jira2markdown
 from jira2markdown.elements import MarkupElements
 from jira2markdown.markup.lists import UnorderedList, OrderedList
 from jira2markdown.markup.text_effects import BlockQuote, Quote, Monospaced
+from jira2markdown.markup.text_breaks import Ruler
 
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
 from markup.text_effects import TweakedBlockQuote, TweakedQuote, TweakedMonospaced
+from markup.text_breaks import LongRuler
+
 
 @dataclass
 class Attachment(object):
@@ -208,6 +211,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}) -> str:
     elements.replace(BlockQuote, TweakedBlockQuote)
     elements.replace(Quote, TweakedQuote)
     elements.replace(Monospaced, TweakedMonospaced)
+    elements.insert_after(Ruler, LongRuler)
     text = jira2markdown.convert(text, elements=elements)
 
     # markup @ mentions with ``

--- a/migration/src/markup/text_breaks.py
+++ b/migration/src/markup/text_breaks.py
@@ -1,0 +1,18 @@
+from pyparsing import Literal, LineEnd, ParserElement, StringStart, replaceWith
+
+from jira2markdown.markup.base import AbstractMarkup
+from jira2markdown.markup.text_breaks import LineBreak
+
+
+class LongRuler(AbstractMarkup):
+    is_inline_element = False
+
+    @property
+    def expr(self) -> ParserElement:
+        # Text with dashed below it turns into a heading. To prevent this
+        # add a line break before the dashes.
+        return (
+            ("\n" | StringStart() | LineBreak(**self.init_kwargs).expr)
+            + Literal("-")[5, ...].setParseAction(replaceWith("\n-----"))
+            + LineEnd()
+        )


### PR DESCRIPTION
#1 

A line break should be inserted before a ruler (sequence of dashes with arbitrary length); otherwise, the following paragraph is interpreted as headers.

error example:
![Screenshot from 2022-07-09 16-59-59](https://user-images.githubusercontent.com/1825333/178097244-abf8f176-5691-4925-82b3-fef163a957ec.png)

with this patch:
![Screenshot from 2022-07-09 17-00-30](https://user-images.githubusercontent.com/1825333/178097259-d5402723-8a71-4203-8917-342bad15b65b.png)
