### PR TITLE
Escape HTML

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -10,7 +10,7 @@ from jira2markdown.markup.text_effects import BlockQuote, Quote, Monospaced
 from jira2markdown.markup.text_breaks import Ruler
 
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
-from markup.text_effects import TweakedBlockQuote, TweakedQuote, TweakedMonospaced
+from markup.text_effects import EscapeHtml, TweakedBlockQuote, TweakedQuote, TweakedMonospaced
 from markup.text_breaks import LongRuler
 
 
@@ -212,6 +212,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}) -> str:
     elements.replace(Quote, TweakedQuote)
     elements.replace(Monospaced, TweakedMonospaced)
     elements.insert_after(Ruler, LongRuler)
+    elements.append(EscapeHtml)
     text = jira2markdown.convert(text, elements=elements)
 
     # markup @ mentions with ``

--- a/migration/src/markup/text_effects.py
+++ b/migration/src/markup/text_effects.py
@@ -9,8 +9,8 @@ from pyparsing import (
     Literal,
     LineEnd,
     Combine,
+    Literal,
     replaceWith,
-
 )
 
 from jira2markdown.markup.base import AbstractMarkup
@@ -57,3 +57,13 @@ class TweakedMonospaced(AbstractMarkup):
     @property
     def expr(self) -> ParserElement:
         return QuotedString("{{", endQuoteChar="}}").setParseAction(self.action)
+
+
+class EscapeHtml(AbstractMarkup):
+    """
+    Escapes HTML characters that are not a part of any expression grammar
+    """
+
+    @property
+    def expr(self) -> ParserElement:
+        return Literal("<").setParseAction(replaceWith("&lt;")) ^ Literal(">").setParseAction(replaceWith("&gt;")) ^ Literal("&").setParseAction(replaceWith("&amp;"))


### PR DESCRIPTION
#1 

HTML characters (`<`, `>` and `&`) that are not a part of any markup elements should be escaped.

Without escaping:
![Screenshot from 2022-07-09 17-57-45](https://user-images.githubusercontent.com/1825333/178099177-96543ca2-b2a9-4942-99c9-44d4d4a888e5.png)

With escaping (this patch):
![Screenshot from 2022-07-09 17-58-21](https://user-images.githubusercontent.com/1825333/178099185-48545eda-1bd3-48e7-a143-1168c43fe1fa.png)
