### PR TITLE
Remap jira name to github account if it is available

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -85,7 +85,7 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
         # make pull requests list
         pull_requests_list = [f"- {x}\n" for x in pull_requests]
 
-        body = f"""{convert_text(description, att_replace_map)}
+        body = f"""{convert_text(description, att_replace_map, account_map)}
 
 ---
 ### Jira information
@@ -117,7 +117,7 @@ Pull Requests:
         comments_data = []
         for (comment_author_name, comment_author_dispname, comment_body, comment_created, comment_updated) in comments:
             data = {
-                "body": f"""{convert_text(comment_body, att_replace_map)}
+                "body": f"""{convert_text(comment_body, att_replace_map, account_map)}
 
 Author: {comment_author(comment_author_name, comment_author_dispname)}
 Created: {comment_created}


### PR DESCRIPTION
Close #24 

Capture all `@username` in issue descriptions and comments (as far as possible), then replace each with GitHub account if the corresponding account is available. If there is no corresponding GitHub account, show Jira username with inline code markup to avoid unintentional mentions.

When corresponding GitHub account is available:

![Screenshot from 2022-07-09 21-42-47](https://user-images.githubusercontent.com/1825333/178106254-99cb60fa-a626-4939-9f29-aa995673c07c.png)

When corresponding GitHub account is not available:

![Screenshot from 2022-07-09 21-43-36](https://user-images.githubusercontent.com/1825333/178106285-fce87fe7-6b47-4c0c-b342-dbb80e509f98.png)
