### PR TITLE
Make converter script work without account mapping file

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -63,7 +63,7 @@ Downloaded attachments should be separately committed to a dedicated branch name
 
 `src/jira2github_import.py` converts Jira dumps into GitHub data that are importable to [issue import API](https://gist.github.com/jonmagic/5282384165e0f86ef105). Converted JSON data is saved in `migration/github-import-data`.
 
-This also resolves all Jira user ID - GitHub account alignment if the account mapping is given in `mapping-data/account-map.csv`.  If you have no mapping, `cp mapping-data/account-map.csv{.example,}`.
+This also resolves all Jira user ID - GitHub account alignment if the account mapping is given in `mapping-data/account-map.csv`.
 
 ```
 (.venv) migration $ python src/jira2github_import.py --min 10500 --max 10510

--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         output_dir.mkdir()
     assert output_dir.exists()
 
-    account_map = read_account_map(account_mapping_file) if account_mapping_file else {}
+    account_map = read_account_map(account_mapping_file) if account_mapping_file.exists() else {}
 
     issues = []
     if args.issues:


### PR DESCRIPTION
I have a second thought about this. It may be better to make the converter script work regardless of whether there is an account mapping file or not (it's not a critical part of the converter).