### PR TITLE
only escape HTML tags

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -10,7 +10,7 @@ from jira2markdown.markup.text_effects import BlockQuote, Quote, Monospaced
 from jira2markdown.markup.text_breaks import Ruler
 
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
-from markup.text_effects import EscapeHtml, TweakedBlockQuote, TweakedQuote, TweakedMonospaced
+from markup.text_effects import EscapeHtmlTag, TweakedBlockQuote, TweakedQuote, TweakedMonospaced
 from markup.text_breaks import LongRuler
 
 
@@ -212,7 +212,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
     elements.replace(Quote, TweakedQuote)
     elements.replace(Monospaced, TweakedMonospaced)
     elements.insert_after(Ruler, LongRuler)
-    elements.append(EscapeHtml)
+    elements.append(EscapeHtmlTag)
     text = jira2markdown.convert(text, elements=elements)
 
     # markup @ mentions with ``

--- a/migration/src/markup/text_effects.py
+++ b/migration/src/markup/text_effects.py
@@ -59,11 +59,11 @@ class TweakedMonospaced(AbstractMarkup):
         return QuotedString("{{", endQuoteChar="}}").setParseAction(self.action)
 
 
-class EscapeHtml(AbstractMarkup):
+class EscapeHtmlTag(AbstractMarkup):
     """
     Escapes HTML characters that are not a part of any expression grammar
     """
 
     @property
     def expr(self) -> ParserElement:
-        return Literal("<").setParseAction(replaceWith("&lt;")) ^ Literal(">").setParseAction(replaceWith("&gt;")) ^ Literal("&").setParseAction(replaceWith("&amp;"))
+        return Literal("<").setParseAction(replaceWith("&lt;")) + SkipTo(Literal(">")) + Literal(">").setParseAction(replaceWith("&gt;"))


### PR DESCRIPTION
Follow-up of #23.
To avoid unintentional escaping, escape only HTML tag-like texts (`<foo bar>`) and preserve other `<`, `>`, and `&`.