### PR TITLE
Catch all exceptions (and proceed to the nexe issue) in jira2github_import.py

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -11,6 +11,7 @@ import json
 import sys
 from urllib.parse import quote
 import os
+import traceback
 
 from common import LOG_DIRNAME, JIRA_DUMP_DIRNAME, GITHUB_IMPORT_DATA_DIRNAME, MAPPINGS_DATA_DIRNAME, ACCOUNT_MAPPING_FILENAME, ISSUE_TYPE_TO_LABEL_MAP, COMPONENT_TO_LABEL_MAP, \
     logging_setup, jira_issue_url, jira_dump_file, jira_issue_id, github_data_file, make_github_title, read_account_map
@@ -211,7 +212,11 @@ if __name__ == "__main__":
 
     logger.info(f"Converting Jira issues to GitHub issues in {output_dir}")
     for num in issues:
-        convert_issue(num, dump_dir, output_dir, account_map, github_att_repo, github_att_branch)
+        try:
+            convert_issue(num, dump_dir, output_dir, account_map, github_att_repo, github_att_branch)
+        except Exception as e:
+            logger.error(traceback.format_exc(limit=100))
+            logger.error(f"Failed to convert Jira issue. An error '{str(e)}' occurred; skipped {jira_issue_id(num)}.")
     
     logger.info("Done.")
 


### PR DESCRIPTION
Added try-catch so that it does not stop with a conversion failure/error.

```
(.venv) migration $ python src/jira2github_import.py --issues 550 551
[2022-07-12 12:16:02,672] INFO:jira2github_import: Converting Jira issues to GitHub issues in /mnt/hdd/repo/lucene-jira-archive/migration/github-import-data
[2022-07-12 12:16:32,570] ERROR:jira2github_import: Traceback (most recent call last):
  File "/mnt/hdd/repo/lucene-jira-archive/migration/src/jira2github_import.py", line 216, in <module>
    convert_issue(num, dump_dir, output_dir, account_map, github_att_repo, github_att_branch)
  File "/mnt/hdd/repo/lucene-jira-archive/migration/src/jira2github_import.py", line 121, in convert_issue
    "body": f"""{convert_text(comment_body, att_replace_map, account_map)}
  File "/mnt/hdd/repo/lucene-jira-archive/migration/src/jira_util.py", line 216, in convert_text
    text = jira2markdown.convert(text, elements=elements)
  File "/mnt/hdd/repo/lucene-jira-archive/migration/.venv/lib/python3.9/site-packages/jira2markdown/parser.py", line 20, in convert
    return markup.transformString(text)
...
RecursionError: maximum recursion depth exceeded

[2022-07-12 12:16:32,570] ERROR:jira2github_import: Failed to convert Jira issue. An error 'maximum recursion depth exceeded' occurred; skipped LUCENE-550.
[2022-07-12 12:16:34,903] INFO:jira2github_import: Done.
```

```
(.venv) migration $ ls -1 github-import-data/
GH-LUCENE-551.json
```