### PR TITLE
Allow to specify number of worker processes for jira2github_import.py

### DIFF
--- a/migration/src/common.py
+++ b/migration/src/common.py
@@ -4,7 +4,8 @@ from datetime import datetime
 import functools
 import time
 import os
-import tempfile
+import multiprocessing
+from logging.handlers import QueueHandler
 
 LOG_DIRNAME = "log"
 
@@ -19,22 +20,65 @@ ACCOUNT_MAPPING_FILENAME = "account-map.csv"
 
 ASF_JIRA_BASE_URL = "https://issues.apache.org/jira/browse"
 
+LOGGING_FOMATTER = logging.Formatter("[%(asctime)s] %(levelname)s:%(module)s: %(message)s")
 
 logging.basicConfig(level=logging.DEBUG, handlers=[])
 
 def logging_setup(log_dir: Path, name: str) -> logging.Logger:
     if not log_dir.exists():
         log_dir.mkdir()
-    formatter = logging.Formatter("[%(asctime)s] %(levelname)s:%(module)s: %(message)s")
     file_handler = logging.FileHandler(log_dir.joinpath(f'{name}_{datetime.now().isoformat(timespec="seconds")}.log'))
     file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(formatter)
+    file_handler.setFormatter(LOGGING_FOMATTER)
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.INFO)
-    console_handler.setFormatter(formatter)
+    console_handler.setFormatter(LOGGING_FOMATTER)
     logger = logging.getLogger(name)
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
+    return logger
+
+
+# helper to support logging to a single file from multiple processes
+# https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes
+def log_listener(log_dir: Path, name: str) -> tuple[multiprocessing.Process, multiprocessing.Queue]:
+
+    def listener_process(queue: multiprocessing.Queue, path: Path):
+        file_handler = logging.FileHandler(path)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(LOGGING_FOMATTER)
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+        console_handler.setFormatter(LOGGING_FOMATTER)
+        root = logging.getLogger()
+        root.addHandler(file_handler)
+        root.addHandler(console_handler)
+
+        while True:
+            try:
+                record: logging.LogRecord = queue.get()
+                if record is None:  # sentinel
+                    break
+                logger = logging.getLogger(record.name)
+                logger.handle(record)
+            except Exception:
+                import sys, traceback
+                print('Whoops! Problem:', file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+
+    if not log_dir.exists():
+        log_dir.mkdir()
+    path = log_dir.joinpath(f'{name}_{datetime.now().isoformat(timespec="seconds")}.log')
+    queue = multiprocessing.Queue(-1)
+    listener = multiprocessing.Process(target=listener_process, args=(queue, path))
+    return (listener, queue)
+
+
+def logging_setup_worker(name: str, queue: multiprocessing.Queue) -> logging.Logger:
+    logger = logging.getLogger(name)
+    queue_handler = QueueHandler(queue)
+    logger.addHandler(queue_handler)
+    logger.setLevel(logging.DEBUG)
     return logger
 
 

--- a/migration/src/common.py
+++ b/migration/src/common.py
@@ -34,6 +34,7 @@ def logging_setup(log_dir: Path, name: str) -> logging.Logger:
     console_handler.setLevel(logging.INFO)
     console_handler.setFormatter(LOGGING_FOMATTER)
     logger = logging.getLogger(name)
+    logger.handlers = []  # clear current handlers
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
     return logger
@@ -74,12 +75,12 @@ def log_listener(log_dir: Path, name: str) -> tuple[multiprocessing.Process, mul
     return (listener, queue)
 
 
-def logging_setup_worker(name: str, queue: multiprocessing.Queue) -> logging.Logger:
-    logger = logging.getLogger(name)
+def logging_setup_worker(queue: multiprocessing.Queue):
+    logger = logging.getLogger()
     queue_handler = QueueHandler(queue)
+    logger.handlers = []  # clear current handlers
     logger.addHandler(queue_handler)
     logger.setLevel(logging.DEBUG)
-    return logger
 
 
 def jira_issue_url(issue_id: str) -> str:

--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -19,9 +19,6 @@ import multiprocessing
 from common import *
 from jira_util import *
 
-#log_dir = Path(__file__).resolve().parent.parent.joinpath(LOG_DIRNAME)
-#logger = logging_setup(log_dir, "jira2github_import")
-
 
 def attachment_url(issue_num: int, filename: str, att_repo: str, att_branch: str) -> str:
     return f"https://raw.githubusercontent.com/{att_repo}/{att_branch}/attachments/{jira_issue_id(issue_num)}/{quote(filename)}"

--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -242,7 +242,7 @@ if __name__ == "__main__":
 
     logger.info(f"Converting Jira issues to GitHub issues in {output_dir}. num_workers={num_workers}")
 
-    def worker(num):
+    def task(num):
         logger = logging.getLogger(name)
         try:
             convert_issue(num, dump_dir, output_dir, account_map, github_att_repo, github_att_branch, logger)
@@ -254,7 +254,7 @@ if __name__ == "__main__":
     # Try to support Windows: The worker configuration is done at the start of the worker process run.
     with multiprocessing.Pool(num_workers, initializer=logging_setup_worker, initargs=(queue,)) as pool:
         for num in issues:
-            result = pool.apply_async(worker, (num,))
+            result = pool.apply_async(task, (num,))
             results.append(result)
         for res in results:
             res.get()


### PR DESCRIPTION
Close #36 

`jira2github_import.py` processes Jira dump files one by one and does not call any HTTP APIs. It should be able to parallelize it with [multiprocessing](https://docs.python.org/3/library/multiprocessing.html).

One problem is how to handle the log file. I implemented the "log listener" pattern following this cookbook.
https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes

Usage:
```
# use four worker processes. a log listener process is also started.
python src/jira2github_import.py --min 9000 --max 9100 --num_workers=4

# all forked processes should be stopped by sending SIGINT to the main process
(Ctrl-C on Linux)
```

If `--num_workers` option is omitted, only one worker and listener processes are started.

Note: I think this code is OS-agnostic, but I haven't used `multiprocessing` on Windows. There might be some pitfalls.