### PR TITLE
fix missed f-strings' "f"

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -100,7 +100,7 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
             logger.error(f"Original description: {description}")
             body = f"```\n{description}```\n\n"
 
-        body += """
+        body += f"""
 
 ---
 ### Legacy Jira details


### PR DESCRIPTION
This is a small follow-up for #40.

![Screenshot from 2022-07-13 21-16-51](https://user-images.githubusercontent.com/1825333/178731400-485ced98-1ca2-4d9b-b7e3-01ff91f78ed6.png)

should be 

![Screenshot from 2022-07-13 21-16-03](https://user-images.githubusercontent.com/1825333/178731273-90cf248b-8899-43e0-b4e2-13a8fda7bce9.png)
