### PR TITLE
Add a script to add 'moved to' comments to Jira issues

### DIFF
--- a/migration/.env.example
+++ b/migration/.env.example
@@ -3,3 +3,4 @@ export GITHUB_REPO=
 export GITHUB_ATT_REPO="apache/lucene-jira-archive"
 export GITHUB_ATT_BRANCH="attachments"
 export ATTACHMENTS_DL_DIR=
+export JIRA_PAT=

--- a/migration/README.md
+++ b/migration/README.md
@@ -142,8 +142,7 @@ Done.
 `src/add_comments_jira_issues.py` adds a comment to each Jira issue to guide users to the corresponding GitHub issue.
 
 ```
-[2022-07-16 10:35:12,684] INFO:add_comments_jira_issues: Done.
-(.venv) migration $ python src/add_comments_jira_issues.py --issues 10622
+(.venv) migration $ python src/add_comments_jira_issues.py
 [2022-07-16 10:35:34,440] INFO:add_comments_jira_issues: Add comments to Jira issues.
 [2022-07-16 10:35:36,338] INFO:add_comments_jira_issues: Done.
 ```

--- a/migration/README.md
+++ b/migration/README.md
@@ -15,15 +15,16 @@ source .venv/bin/activate
 (.venv) pip install -r requirements.txt
 ```
 
-You need a GitHub repository and [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for testing. Set `GITHUB_PAT` and `GITHUB_REPO` environment variables. See `.env.example` for other variables.
+You need a GitHub repository and [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for testing. Set `GITHUB_PAT` and `GITHUB_REPO` environment variables. For adding "moved to GitHub" comments to Jira side, you also need Jira [personal access token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html). See `.env.example` for other variables.
 
 On Linux/MacOS:
 ```
 cp .env.example .env
 
 vi .env
-export GITHUB_PAT=<your token>
+export GITHUB_PAT=<your GitHub token>
 export GITHUB_REPO=<your repository location> # e.g. "mocobeta/sandbox-lucene-10557"
+export JIRA_PAT=<your Jira token>
 
 source .env
 ```
@@ -135,6 +136,20 @@ Second pass: `src/update_issues.py` updates issues and comments with updated iss
 [2022-07-16 09:18:42,274] INFO:update_issue_labels: 63 labels are found.
 Done.
 ```
+
+### 8. Add "Moved to" comments to Jira issues
+
+`src/add_comments_jira_issues.py` adds a comment to each Jira issue to guide users to the corresponding GitHub issue.
+
+```
+[2022-07-16 10:35:12,684] INFO:add_comments_jira_issues: Done.
+(.venv) migration $ python src/add_comments_jira_issues.py --issues 10622
+[2022-07-16 10:35:34,440] INFO:add_comments_jira_issues: Add comments to Jira issues.
+[2022-07-16 10:35:36,338] INFO:add_comments_jira_issues: Done.
+```
+
+Note that this may trigger Jira notfication mails.
+
 
 ### How to Generate Account Mapping
 

--- a/migration/src/add_comments_jira_issues.py
+++ b/migration/src/add_comments_jira_issues.py
@@ -1,0 +1,93 @@
+import argparse
+import os
+import sys
+from logging import Logger
+from pathlib import Path
+import requests
+import time
+import requests
+from common import *
+
+log_dir = Path(__file__).resolve().parent.parent.joinpath(LOG_DIRNAME)
+logger = logging_setup(log_dir, "add-comments-jira-issues")
+
+JIRA_API_BASE = "https://issues.apache.org/jira/rest/api/latest"
+INTERVAL_IN_SECONDS = 1.0
+
+
+def __read_issue_url_map(issue_mapping_file: Path) -> dict[str, int]:
+    url_map = {}
+    with open(issue_mapping_file) as fp:
+        fp.readline()  # skip header
+        for line in fp:
+            cols = line.strip().split(",")
+            if len(cols) < 3:
+                continue
+            url_map[cols[0]] = cols[1]  # jira issue key -> github issue url
+    return url_map
+
+
+def __add_comment(token: str, issue_number: int, comment: str, logger: Logger) -> bool:
+    url = JIRA_API_BASE + f"/issue/{jira_issue_id(issue_number)}/comment"
+    headers = {"Authorization": f"Bearer {token}"}
+    data = {"body": comment}
+    res = requests.post(url, headers=headers, json=data)
+    time.sleep(INTERVAL_IN_SECONDS)
+    if res.status_code != 201:
+        logger.error(f"Failed to add a comment to {jira_issue_id(issue_number)}")
+        return False
+    return True
+
+
+@retry_upto(3, 1.0, logger)
+def add_moved_to_comment(token: str, issue_number: int, github_url: str) -> bool:
+    comment = f"""[TEST] This was moved to GitHub issue: {github_url}."""
+    res = __add_comment(token, issue_number, comment, logger)
+    if res:
+        logger.debug(f"Added a comment to {jira_issue_id(issue_number)}")
+    return res
+
+
+if __name__ == "__main__":
+    jira_token = os.getenv("JIRA_PAT")
+    if not jira_token:
+        print("Please set your Jira token to JIRA_PAT environment variable.")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--issues', type=int, required=False, nargs='*', help='Jira issue number list to be downloaded')    
+    parser.add_argument('--min', type=int, dest='min', required=False, default=1, help='Minimum (inclusive) Jira issue number to be downloaded')
+    parser.add_argument('--max', type=int, dest='max', required=False, help='Maximum (inclusive) Jira issue number to be downloaded')
+    args = parser.parse_args()
+
+    mapping_data_dir = Path(__file__).resolve().parent.parent.joinpath(MAPPINGS_DATA_DIRNAME)
+    issue_mapping_file = mapping_data_dir.joinpath(ISSUE_MAPPING_FILENAME)
+    if not issue_mapping_file.exists():
+        logger.error(f"Jira-GitHub issue id mapping file not found. {issue_mapping_file}")
+        sys.exit(1)
+    issue_url_map = __read_issue_url_map(issue_mapping_file)
+
+    issues = []
+    if args.issues:
+        issues = args.issues
+    else:
+        if args.max:
+            issues.extend(list(range(args.min, args.max + 1)))
+        else:
+            issues.append(args.min)
+
+    logger.info("Add comments to Jira issues.")
+
+    for num in issues:
+        issue_id = jira_issue_id(num)
+        github_url = issue_url_map.get(issue_id)
+        if not github_url:
+            logger.warning(f"No corresponding GitHub issue for {issue_id}.")
+            continue
+        try:
+            add_moved_to_comment(jira_token, num, github_url)
+        except MaxRetryLimitExceedException:
+            logger.error(f"Failed to update issue comments. Skipped {issue_id}.")
+
+    logger.info("Done.")
+


### PR DESCRIPTION
#15 

With a [personal access token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) (of a committer?), it is possible to add comments to ASF Jira issues.

![Screenshot from 2022-07-16 10-56-42](https://user-images.githubusercontent.com/1825333/179334326-407d1153-fa74-42af-8524-723446e3dbcf.png)

Note that this sends notifications to issues@ mail list (per POST API call). I think it's fine to let users know about the migration - an announcement for devs would be needed beforehand though.
