### PR TITLE
Show issue title for linked issues

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -71,12 +71,12 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
         # embed github issue number next to linked issue keys
         linked_issues_list_items = []
         for jira_key in linked_issues:
-            linked_issues_list_items.append(f"[{jira_key}]({jira_issue_url(jira_key)})")
+            linked_issues_list_items.append(f"- [{jira_key}]({jira_issue_url(jira_key)})\n")
         
         # embed github issue number next to sub task keys
         subtasks_list_items = []
         for jira_key in subtasks:
-            subtasks_list_items.append(f"[{jira_key}]({jira_issue_url(jira_key)})")
+            subtasks_list_items.append(f"- [{jira_key}]({jira_issue_url(jira_key)})\n")
 
         created_datetime = dateutil.parser.parse(created)
         updated_datetime = dateutil.parser.parse(updated)
@@ -109,10 +109,10 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
             body += f'\nAttachments: {", ".join(attachment_list_items)}'
 
         if len(linked_issues_list_items) > 0:
-            body += f'\nLinked issues: {", ".join(linked_issues_list_items)}'
+            body += f'\nLinked issues:\n {"".join(linked_issues_list_items)}'
 
         if len(subtasks_list_items) > 0:
-            body += f'\nSub-tasks: {", ".join(subtasks_list_items)}'
+            body += f'\nSub-tasks:\n {"".join(subtasks_list_items)}'
 
         if len(pull_requests) > 0:
             body += f'\nPull requests: {", ".join([str(x) for x in pull_requests])}'

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -239,7 +239,6 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, str]) -> str:
         gh_number = issue_id_map.get(m.group(2))
         if gh_number:
             res = f"{m.group(1)}#{gh_number}{m.group(3)}"
-            # print(res)
         return res
     
     def repl_paren(m: re.Match):
@@ -247,7 +246,6 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, str]) -> str:
         gh_number = issue_id_map.get(m.group(2))
         if gh_number:
             res = f"{m.group(1)}#{gh_number}{m.group(3)}"
-            # print(res)
         return res
 
     def repl_bracket(m: re.Match):
@@ -255,7 +253,6 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, str]) -> str:
         gh_number = issue_id_map.get(m.group(2))
         if gh_number:
             res = f"#{gh_number}"
-            # print(res)
         return res
     
     def repl_md_link(m: re.Match):
@@ -263,7 +260,7 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, str]) -> str:
         gh_number = issue_id_map.get(m.group(1))
         if gh_number:
             res = f"{m.group(0)} (#{gh_number})"
-            print(res)
+            # print(res)
         return res
 
     text = re.sub(r"(\s)(LUCENE-\d+)([\s,\?\!\.])", repl_simple, text)


### PR DESCRIPTION
#27 

After cross-issue link remapping, Linked-issues and Sub-tasks look like this.
![Screenshot from 2022-07-18 15-02-29](https://user-images.githubusercontent.com/1825333/179452982-4daa38d8-a881-4a36-8aaa-0524f829ace2.png)

I would like to make it a "list" to show issue titles for remapped issues like this. 
GitHub frontend shows issue titles if there are sufficient spaces.

![Screenshot from 2022-07-18 15-05-22](https://user-images.githubusercontent.com/1825333/179453246-ad7ebe05-1205-4e84-81c0-8b868a2c283e.png)
