### PR TITLE
Check issue key when downloading

### DIFF
--- a/migration/src/download_jira.py
+++ b/migration/src/download_jira.py
@@ -41,12 +41,12 @@ def download_issue(num: int, dump_dir: Path) -> bool:
     if res.status_code != 200:
         logger.warning(f"Can't download {issue_id}. status code={res.status_code}, message={res.text}")
         return False
+    data = res.json()
+    if data["key"] != issue_id:
+        logger.warning(f"The issue key {data['key']} does not match the request key {issue_id}. Maybe this was moved.")
+        return False
     dump_file = jira_dump_file(dump_dir, num)
     with open(dump_file, "w") as fp:
-        data = res.json()
-        if data["key"] != issue_id:
-            logger.warning(f"The issue key {data['key']} does not match the request key {issue_id}. Maybe this was moved.")
-            return False
         json.dump(data, fp, indent=2)
     logger.debug(f"Jira issue {issue_id} was downloaded in {dump_file}.")
     return True

--- a/migration/src/download_jira.py
+++ b/migration/src/download_jira.py
@@ -43,7 +43,11 @@ def download_issue(num: int, dump_dir: Path) -> bool:
         return False
     dump_file = jira_dump_file(dump_dir, num)
     with open(dump_file, "w") as fp:
-        json.dump(res.json(), fp, indent=2)
+        data = res.json()
+        if data["key"] != issue_id:
+            logger.warning(f"The issue key {data['key']} does not match the request key {issue_id}. Maybe this was moved.")
+            return False
+        json.dump(data, fp, indent=2)
     logger.debug(f"Jira issue {issue_id} was downloaded in {dump_file}.")
     return True
 


### PR DESCRIPTION
Suggested in #37.

If the top-level "key" value does not match the request key, the issue has moved to another issue and should be excluded from migration.

```
(.venv) migration $ python src/download_jira.py --issues 4344
[2022-07-19 20:41:06,578] INFO:download_jira: Downloading Jira issues in /mnt/hdd/repo/lucene-jira-archive/migration/jira-dump. Attachments are saved in /tmp/attachments.
[2022-07-19 20:41:07,692] WARNING:download_jira: The issue key SOLR-3769 does not match the request key LUCENE-4344. Maybe this was moved.
[2022-07-19 20:41:08,194] INFO:download_jira: Done.

# no file for the moved issue was created.
(.venv) migration $ ls jira-dump/LUCENE-4344.json 
"jira-dump/LUCENE-4344.json": No such file or directory (os error 2)
```