### PR TITLE
Handle tilde mentions

### DIFF
--- a/migration/mappings-data/jira-users.csv.20220722
+++ b/migration/mappings-data/jira-users.csv.20220722
@@ -1,0 +1,2268 @@
+JiraName,DispName
+jira-bot,ASF subversion and git services
+mikemccand,Michael McCandless
+rcmuir,Robert Muir
+uschindler,Uwe Schindler
+jpountz,Adrien Grand
+sarowe,Steven Rowe
+dweiss,Dawid Weiss
+simonw,Simon Willnauer
+dsmiley,David Smiley
+hossman,Chris M. Hostetter
+shaie,Shai Erera
+yseeley@gmail.com,Yonik Seeley
+gsingers,Grant Ingersoll
+markrmiller@gmail.com,Mark Miller
+romseygeek,Alan Woodward
+commit-tag-bot,Commit Tag Bot
+ivera,Ignacio Vera
+anshum,Anshum Gupta
+java-dev@lucene.apache.org,Lucene Developers
+shalin,Shalin Shekhar Mangar
+paul.elschot@xs4all.nl,Paul Elschot
+michaelbusch,Michael Busch
+erickerickson,Erick Erickson
+otis,Otis Gospodnetic
+sokolov,Michael Sokolov
+doronc,Doron Cohen
+cmale,Chris Male
+otis@apache.org,Otis Gospodnetic
+rjernst,Ryan Ernst
+jim.ferenczi,Jim Ferenczi
+kwright@metacarta.com,Karl Wright
+janhoy,Jan Høydahl
+tomoko,Tomoko Uchida
+jasonrutherglen,Jason Rutherglen
+earwin,Earwin Burrfoot
+thelabdude,Timothy Potter
+lucenesolrqa,Lucene/Solr QA
+nknize,Nick Knize
+cpoerschke,Christine Poerschke
+daniel.naber@t-online.de,Daniel Naber
+Gromov,Peter Gromov
+martijn.v.groningen,Martijn van Groningen
+gsmiller,Greg Miller
+cutting,Doug Cutting
+broustant,Bruno Roustant
+githubbot,ASF GitHub Bot
+mdrob,Mike Drob
+karl.wettin,Karl Wettin
+mkhl,Mikhail Khludnev
+lucenebugs@danielnaber.de,Daniel Naber
+teofili,Tommaso Teofili
+elyograg,Shawn Heisey
+koji,Koji Sekiguchi
+atris,Atri Sharma
+mharwood,Mark Harwood
+julietibs,Julie Tibshirani
+ehatcher,Erik Hatcher
+ryantxu,Ryan McKinley
+ab,Andrzej Bialecki
+cutting@apache.org,cutting@apache.org
+john.wang@gmail.com,John Wang
+mayya,Mayya Sharipova
+jakarta@ehatchersolutions.com,Erik Hatcher
+trejkaz,Trejkaz
+jkrupan,Jack Krupansky
+atri,Atri Sharma
+dnhatn,Nhat Nguyen
+marvin,Marvin Humphrey
+eksdev,Eks Dev
+tsmith,Tim Smith
+cm,Christian Moen
+goller@detego-software.de,Christoph Goller
+iorixxx,Ahmet Arslan
+steven_parkes,Steven Parkes
+dmsmith,DM Smith
+varun,Varun Thacker
+selckin,selckin
+zacharymorn,Zach Chen
+danmuzi,Namgyu Kim
+kimchy,Shay Banon
+ichattopadhyaya,Ishan Chattopadhyaya
+adriano_crestani,Adriano Crestani
+ctargett,Cassandra Targett
+tallison,Tim Allison
+areek,Areek Zillur
+ChrisLu,Lu Xugang
+gf2121,Feng Guo
+gilad,Gilad Barkai
+gworah,Gautam Worah
+bmargulies,Benson Margulies
+lucacavanna,Luca Cavanna
+mbraun688,Michael Braun
+lancenorskog,Lance Norskog
+manawiz,Chuck Williams
+mayyas,Mayya Sharipova
+abenedetti,Alessandro Benedetti
+lafa,Luis Alves
+markus17,Markus Jelsma
+arafalov,Alexandre Rafalovitch
+tflobbe,Tomas Eduardo Fernandez Lobbe
+vajda,Andi Vajda
+shebiki,Terry Smith
+jimczi,Jim Ferenczi
+hibou,Nicolas Lalevée
+eisakson,Eric Isakson
+rengels@ix.netcom.com,robert engels
+toke,Toke Eskildsen
+simonwillnauer,Simon Willnauer
+billy,Han Jiang
+magibney,Michael Gibney
+bernhard.messer@intrafind.de,Bernhard Messer
+zhai7631,Patrick Zhai
+billnbell,Bill Bell
+andyetitmoves,Ramkumar Aiyengar
+ningli,Ning Li
+jtibshirani,Julie Tibshirani
+gus,Gus Heck
+itamar,Itamar Syn-Hershko
+vigyas,Vigya Sharma
+nyh,Nadav Har'El
+christophk,Christoph Kaser
+bruno.roustant,Bruno Roustant
+krisden,Kevin Risden
+cnstar9988,Littlestar
+rmp91,Rishabh Patel
+karthick,Karthick Sankarachary
+caomanhdat,Cao Manh Dat
+kawai,Hiroaki Kawai
+renaud.delbru,Renaud Delbru
+psmith@apache.org,Paul Smith
+klaasm,Mike Klaas
+tburtonwest,Tom Burton-West
+jdconradson,Jack Conradson
+robau,Rob Audenaerde
+djelinski,Daniel Jelinski
+jdyer,James Dyer
+lvl,Luc Vanlerberghe
+gerlowskija,Jason Gerlowski
+gbowyer@fastmail.co.uk,Greg Bowyer
+david_nemeskey,David Mark Nemeskey
+kaykay.unique,Karthik K
+kamaci,Furkan Kamaci
+pcowan,Paul Cowan
+jbernste,Joel Bernstein
+spo,Stefan Pohl
+halleux.jf@skynet.be,Jean-François Halleux
+ck@newsclub.de,Christian Kohlschütter
+dakrone,Lee Hinman
+munendrasn,Munendra S N
+Timothy055,Timothy M. Rodriguez
+khitrin,Nikolay Khitrin
+yutinggan,Yuting Gan
+mattweber,Matt Weber
+nik9000@gmail.com,Nik Everett
+dancollins,Daniel Collins
+alukanin,Artem Lukanin
+woody.anderson@gmail.com,Woody Anderson
+kkewwei,kkewwei
+asalamon74,Andras Salamon
+johtani,Jun Ohtani
+nicolas.helleringer,Nicolas Helleringer
+markharw00d@yahoo.co.uk,Mark Harwood
+mdmarshmallow,Marc D'Mello
+nppoly,Chongchen Chen
+noble.paul,Noble Paul
+spike.liu,spike liu
+arcadius,Arcadius Ahouansou
+goankur,Ankur
+dmsmith555,DM Smith
+buschmic,Michael Busch
+andyhind,Andy Hind
+msokolov@gmail.com,Mike Sokolov
+chrismattmann,Chris A. Mattmann
+tamm,Steven Tamm
+bnekkare,Brijesh Nekkare
+pjaol,Patrick O'Leary
+sivany,Sivan Yogev
+sanne,Sanne Grinovero
+juan.duran,juan camilo rodriguez duran
+siren,Sami Siren
+pkeegan,Peter Keegan
+wunder,Walter Underwood
+crocket,crocket
+adriannistor,Adrian Nistor
+h.kazuaki,Kazuaki Hiraga
+jukkaz,Jukka Zitting
+sebb,Sebb
+hypothesisx86,Tony Xu
+cbismuth,Christophe Bismuth
+sstults,Scott Stults
+rnewson,Robert Newson
+rengels@tylertechinc.com,robert engels
+ejain,Eric Jain
+tkrah,Torsten Krah
+upayavira,Upayavira
+shahrs87,Rushabh Shah
+houston,Houston Putman
+dmitry_key,Dmitry Kan
+wjp719,jianping weng
+guangtai,Guangtai Liang
+erickoerickson,Erick Erickson
+imotov,Igor Motov
+ddreon1@yahoo.com,dan
+jedws,Jed Wesley-Smith
+cbuescher,Christoph Büscher
+ntankovic,Nikola Tankovic
+edwardd,Edward Drapkin
+ryguasu,Chris Harris
+rchyla,Roman Chyla
+arysin,Andriy Rysin
+drzhonghao,Hao Zhong
+shikhar,Shikhar Bhushan
+cedrik_lime,Cédrik LIME
+ijabz,Paul taylor
+brainlounge,Bernd Fondermann
+hyan,An Hong Yun
+lukas.vlcek,Lukas Vlcek
+digydigy,Digy
+grant_ingersoll@yahoo.com,Grant Ingersoll
+michele,Michele Mazzucco
+funtick,Fuad Efendi
+iuliux,Iulius Curt
+softwaredoug,Doug Turnbull
+micpalmia,Michele Palmia
+mdz-munich,Sebastian Lutze
+dejannenov,Dejan Nenov
+chuck@manawiz.com,Chuck Williams
+gunnar,Gunnar Wagenknecht
+npellow,Nick Pellow
+dbowen,David Bowen
+giladbarkai,Gilad Barkai
+y100421,YOO JEONGIN
+julien.nioche@lingway.com,julien nioche
+jvolkman,Jeremy Volkman
+ofavre,Olivier Favre
+reta,Andriy Redko
+randy@zillow.com,Randy Puttick
+jake.mannix,Jake Mannix
+christianz,Christian Ziech
+Trey Jones,Trey Jones
+nicoo_@hotmail.com,Nicolas Maisonneuve
+iprovalo,Ivan Provalov
+msfroh,Michael Froh
+sarkaramrit2@gmail.com,Amrit Sarkar
+dawidweiss,Dawid Weiss
+epugh,Eric Pugh
+whoschek@lbl.gov,hoschek
+marklassau,Mark Lassau
+marcussorealheis,Marcus Eagan
+amordo@infosciences.com,Aviran Mordo
+diegoceccarelli,Diego Ceccarelli
+tpeuss,Thomas Peuss
+Geoffrey Lawson,Geoffrey Lawson
+gmcdonald,Gavin McDonald
+ywelsch,Yannick Welsch
+jjayaprasad@participate.com,Jay Jayaprasad
+kuhn,Jiri Kuhn
+adamwalz,Adam Walz
+wheijke,Wouter Heijke
+joecabrera,Joe Cabrera
+markus_heiden,Markus Heiden
+tdunning,Ted Dunning
+smolav,Santiago M. Mola
+jch,John Haxby
+svella,Shon Vella
+blaplante@netwebapps.com,Bryan LaPlante
+bleskes,Boaz Leskes
+switchhook,Matt Ericson
+tracy.pleasant@lmco.com,Tracy Pleasant
+ddillard,David Dillard
+stanislaw.osinski,Stanislaw Osinski
+dm,Daniel Mitterdorfer
+pierrick.brihaye@free.fr,Pierrick Brihaye
+steven.bethard,Steven Bethard
+janechang,jane chang
+hsn,Radim Kolar
+hlavki,Michal Hlavac
+tfeak,Todd Feak
+akjain,Ankit Jain
+janwari,Jahangir Anwari
+armbrust,Dan Armbrust
+prog,Pawel Rog
+lgjut,Gang Luo
+alex+news@olmisoft.com,Alexey Panchenko
+mdavis95,Matt Davis
+dets,Alexei Dets
+gregtarr,Greg Tarr
+liupanfeng,liupanfeng
+dadoonet,David Pilato
+tn,Thomas Neidhart
+morus.walter@gmx.de,Morus Walter
+oobles,David Ryan
+marc.morissette,Marc Morissette
+michael-o,Michael Osipov
+otmar,Otmar Caduff
+stefanvodita,Stefan Vodita
+timmsc,Sean Timm
+marumarutan,Martin Amirault
+tsturge,Tim Sturge
+andy.miller@cexp.com,Andrig T. Miller
+ronniek,Ronnie Kolehmainen
+varunshenoy,Varun  V Shenoy
+tangdh,tangdh
+yuanyun.cn,jefferyyuan
+hdiwan,Hasan Diwan
+xabbu42,Nathan Gass
+mgainty@hotmail.com,Martin Gainty
+ninglili,Ning Li
+wonlay,Lei Wang
+niqueco,Nicolás Lichtmaier
+vbychkoviak,Volodymyr Bychkoviak
+xiaoshi_2021,xiaoshi
+KoenDG,Koen De Groote
+s4ke,Martin Braun
+dcausse,David Causse
+amccurry,Aaron McCurry
+mreutegg,Marcel Reutegger
+shinichiro abe,Shinichiro Abe
+rnewson@connected.com,Robert Newson
+tpunder,Tim Underwood
+appler,Cheolgoo Kang
+cpa199,Carl Austin
+hani,Hani Suleiman
+esmond.pitt@bigpond.com,Esmond Pitt
+zabetak,Stamatis Zampetakis
+dvhv_sekhar,Sekhar
+spamdaemon,Raimund Merkert
+k317h,Keith Laban
+rcolmegna@tiscali.it,rcolmegna
+ianeboston,Ian Boston
+drew.farris,Drew Farris
+olcbean,olcbean
+sudarshan,Sudarshan Gaikaiwari
+annanik,Anna Björk Nikulásdóttir
+kohlschuetter,Christian Kohlschuetter
+konradk@ca.ibm.com,Konrad Kolosowski
+sdavids,Steve Davids
+shayantabrizi,Shayan Tabrizi
+sqshq,Alexander Lukyanchikov
+nshupe,Nicholaus Shupe
+rendel,Renaud Delbru
+jkloos,Johannes Kloos
+jly,Jingkei Ly
+dkaelbling@blackducksoftware.com,David Kaelbling
+ochrist,Oliver Christ
+clamprecht@gmail.com,Chris Lamprecht
+torcsvarig,Gergő Törcsvári
+nightowl888,Shad Storhaug
+apache-bugzilla@sebastian-kirsch.org,Sebastian Kirsch
+wese,Frank Wesemann
+wgh8089,Bill Herbert
+dragonsinth,Scott Blum
+curtispd,Curtis d'Entremont
+lboutros,Ludovic Boutros
+tkurosaka,Kuro Kurosaka
+joma,Jonathan Mamou
+alynch,Andrew Lynch
+jmwap,jmwap
+luca.stancapiano,Luca Stancapiano
+jamieb22,Jamie
+sgarland,Scott Garland
+itsadok,Israel Tsadok
+motinis,Moti Nisenson
+adb,Antony Bowesman
+chilling,Florian Schilling
+nik9000,Nik Everett
+luyuncheng,LuYunCheng
+ats37@hotmail.com,Andrew Stevens
+ohutchison,Oliver Hutchison
+rbowen,Rich Bowen
+jaywoo123,Jaewoo Kim
+athoune,Mathieu Lecarme
+sits,David Sitsky
+alioral,Ali Oral
+antiheld,André 
+nhooey,Neil Hooey
+steff1193,Per Steffensen
+hgadre,Hrishikesh Gadre
+rasik.pandey@ajlsm.com,Rasik Pandey
+gquaire,Gérald Quaire
+GushGG,Chang KaiShin
+elbek.dev@gmail.com,Elbek Kamoliddinov
+anakot,Anand Kotriwal
+mewmewball,Jessica Cheng Mallet
+rooneg,Garrett Rooney
+bjarkebm2,Bjarke Mortensen
+jmassenet-rakuten,Julien Massenet
+bruce@jivesoftware.com,Bruce Ritchie
+grhoten,George Rhoten
+brian-apache@slesinsky.org,Brian Slesinsky
+bassem.elsayed@bibalex.org,Bassem Elsayed Saad
+stevenschlansker,Steven Schlansker
+siberski@learninglab.de,Wolf Siberski
+ibrahim,Ibrahim
+saturnism@gmail.com,Ray Tsang
+sejalpawar,Sejal Pawar
+berryman,John Berryman
+linuxologist,Michael Goddard
+lewismc,Lewis John McGibbney
+ekeller,Emmanuel Keller
+andyliu1227,Andy Liu
+whoschek,Wolfgang Hoschek
+huynmg,Nguyen Minh Gia Huy
+whwhzzz,Wang Han
+emaijala,Ere Maijala
+peng,Peng Cheng
+alexeylef,Alexey Lef
+muralikpbhat,Murali Krishna P
+hossman_apachebugz@fucit.org,Hoss Man (Legacy Bugzilla Account)
+qforce,Nam-Quang Tran
+mariusneo,Marius Grama
+natta@th.ibm.com,Nattapong Sirilappanich
+chegar999,Chris Hegarty
+tsmorton,Tom Morton
+alex.ksikes,Alex Ksikes
+tlai@leversoft.com,Tony Lai
+mikko@noromaa.fi,Mikko Noromaa
+jsurls,Joey Surls
+jacob@niku.com,Jacob Throgmorton
+viral.gandhi,Viral Gandhi
+rlauck,Ryan Lauck
+salk31,Sam Hough
+fancyerii,LiLi
+Jaison,Jaison.Bi
+spyk,Spyros Kapnissis
+dungba,Anh Dung Bui
+nicola.buso,Nicola Buso
+krka,Kristofer Karlsson
+kaivalnp,Kaival Parikh
+markrmiller,Mark Robert Miller
+Mesbah,Mesbah Alam
+jstuyts,Johan Stuyts
+alexvigdor,Alex Vigdor
+lingchao,xia0c
+kguelzau@novomind.com,Kai Gülzau
+amdonov,Aaron Donovan
+drag0n2@yahoo.com,Eugene Gluzberg
+publicocean0,Cristian Lorenzetto
+colings86,Colin Goodheart-Smithe
+kuzminva,Vladimir Kuzmin
+klangman,Kevin Langman
+matmarie,Mathieu Marie
+lzap@seznam.cz,Lukas Zapletal
+wdq2001_0001@163.com,wang
+nick.menere,Nick Menere
+dbyrne,David Byrne
+mdodsworth,Michael Dodsworth
+ronnie.kolehmainen@ub.uu.se,Ronnie
+vladimir.dolzhenko,Vladimir Dolzhenko
+original-brownbear,Armin Braun
+rvarlikli@yahoo.com,Ramazan VARLIKLI
+shinya,Shinya Kasatani
+lucene@ziplip.com,Arvind Srinivasan
+djd,Daniel John Debrunner
+sujitpal,Sujit Pal
+ben.manes,Ben Manes
+cormac@siderean.com,Cormac Twomey
+befehl,Bernd Fehling
+kmccammon,Keiron McCammon
+gyngve,Gary Yngve
+haydenmuhl,Hayden Muhl
+lebedkov,Tim Lebedkov
+ehaubert,Elizabeth Haubert
+joeshaw,Joe Shaw
+ThomasPoppe,Thomas Poppe
+instagibb,Andrew Gibb
+karlnicholas,Karl Nicholas
+rahul4talk,Rahul Yadav
+nick.smith@techop.ch,Nick Smith
+quentinp,Quentin Pradet
+matthjw,Matthew Willson
+jglick@netbeans.org,Jesse Glick
+wls,Walt Stoneburner
+karlvr,Karl von Randow
+rjosal,Ryan Josal
+sunkuet02,Md. Abdulla-Al-Sun
+aptosca,Steven Parkes
+cahall,Ted Cahall
+kgeis,Ken Geis
+ryd,Jens Muecke
+yingandrews,Ying Andrews
+bitl@mail.ru,Serge A. Redchuk
+michaelklatt,Michael Klatt
+stefant,Stefan Trcek
+hanson@reactivity.com,Michael Hanson
+juangrande,Juan Grande
+ndushay,Naomi Dushay
+mlissner,Mike Lissner
+mgoddard,Michael Goddard
+jzemerick,Jeff Zemerick
+wangsonging,song
+dmeehl,Dan Meehl
+clofresh,Carlo Cabanilla
+JiangHongTiao,Juraj Jurčo
+zhygr,Aliaksandr Zhuhrou
+buzztaiki,Taiki Sugawara
+clintongormley,Clinton Gormley
+TomMortimer,Tom Mortimer
+ucbmckee,Aaron McKee
+johkin,Johan Kindgren
+pbugalski_dynatrace,Paweł Bugalski
+vfunstein,Vitaly Funstein
+iholsman,Ian Holsman
+dedian,Dedian Guo
+briangardner,Brian Gardner
+bripink,Brian Pinkerton
+ghidi,Bogdan Ghidireac
+testn,Testo Nakada
+shinhwei,SHIN HWEI TAN
+oren.ovadia,Oren Ovadia
+henriquecs,Henrique Carvalho Silva
+sberents@hotmail.com,Sander
+lelelombardi@libero.it,Emanuele Lombardi
+stuhood,Stu Hood
+kkrugler,Kenneth William Krugler
+i30817,i30817
+brogar,Chris
+kevinoliver,Kevin Oliver
+elmervc,Elmer van Chastelet
+houstonputman,Houston Putman
+dborowitz,Dave Borowitz
+abakle,Aditya
+bkeil@mouthpunch.com,Benjamin Keil
+fommil,Sam Halliday
+nimarukan,Nimarukan
+gritmind,Yeongsu Kim
+mihai caraman,Mihai Caraman
+chedong@hotmail.com,Che Dong
+danrapp@comcast.net,Dan Rapp
+wormday,sun wuqiang
+shahamish150294,Amish Shah
+pavithraK,pavithra kariyawasam
+peina,peina
+janpascal,Jan-Pascal
+anithian,Amit Nithian
+cetra3,Cetra Free
+ijuma,Ismael Juma
+whzz,Aleksandra Wozniak
+mosadiq,Mohammad Sadiq
+toru,Toru Matsuzawa
+manokovacs,Mano Kovacs
+lfcnassif,Luís Filipe Nassif
+eelstretching,Stephen Green
+masaru,Masaru Hasegawa
+phillipe.ramalho,Phillipe Ramalho
+jacse,Jacob Lauritzen
+nikola,Nikola Smolenski
+cedrik.lime@gmail.com,Cédrik LIME
+dcalvo@task.com.br,Daniel Calvo
+richso@i-cable.com,richso
+steffkes,Stefan Matheis
+eric@conveysoftware.com,Eric Friedman
+cvandenberg,Cameron VandenBerg
+thomasm,Thomas Mueller
+tomsh,TomShally
+sturlese,Marc Sturlese
+adelapena,Andres de la Peña
+hermes,Amir Hadadi
+fhopf,Florian Hopf
+jtibs,Julie Tibshirani
+briangoetz@apache.org,Brian Goetz
+gglouser,Grant Glouser
+zasnuty,Piotr
+erlendfg,Erlend Garåsen
+goksron,Lance Norskog
+ChrisHegarty,Chris Hegarty
+irislpx,Peixin Li
+antonmry,Anton R. Yuste
+umishu,Shuji Umino
+peger@automotive.com,Patrick Eger
+jguyenot,Guyenot Jeremy
+talktoudaykunar,uday kumar maddigatla
+dlr@finemaltcoding.com,Daniel Rall
+tcn,Timo Nentwig
+bingosxs,Xiaoshan Sun
+jrduncans,Stephen Charles Duncan, Jr.
+tvaishna,Tapan Vaishnav
+lulog1,Michael Schlegel
+jerryzhou1,Jerry Zhou
+zhanghuangzhu,Zhang Huang Zhu
+billowgao,Billow Gao
+mbogosian,Matthew Bogosian
+tjones@hoovers.com,tjones
+xiaoyanggu,Xiaoyang Gu
+matthias.seidel,Matthias Seidel
+sgbridges,Sean Bridges
+jamienz@yahoo.com,Jamie
+GregVisotski,Greg Visotski
+veita,Alexander Veit
+pmularien@deploy.com,Peter Mularien
+rwesten,Rupert Westenthaler
+seanoc5,Sean O'Connor
+gsobczyk,Grzegorz Sobczyk
+nuz,Quentin BIOJOUT
+mindas,Mindaugas Žakšauskas
+sven.ruwolt@gaussvip.com,sven ruwolt
+weizijun,weizijun
+chris morris,Christopher Morris
+shjavidnia@yahoo.com,Shahram Javidnia
+pcsanwald,Paul Sanwald
+chengfengfeng,FengFeng Cheng
+kareltejnora,Karel Tejnora
+georgearoush,George Aroush
+praste,Pushkar Raste
+uihyun,Uihyun Kim
+hshankar,Hari Menon
+tomhecker,Thomas Hecker
+holograph,Tomer Gabel
+drissman@acm.org,Avi Drissman
+yixunx,Yixun Xu
+craigtaverner,Craig Taverner
+dmitrymalinin,Dmitry Malinin
+hanwen,Han-Wen NIenhuys
+apeteri,András Péteri
+huyyuh,Huy Le
+ehartford,Eric R Hartford
+jprante,Jörg Prante
+huzi,Thomas Lemmé
+andrzej.jarmoniuk@e-point.pl,Andrzej Jarmoniuk
+bwhitman,Brian Whitman
+Fatalityap,Alexey Ponomarenko
+sam@redspr.com,sam
+rstupp@pironet-ndh.com,Ursus von den Haflingern
+ajhalani,ankush jhalani
+sasashin,Shingo Sasaki
+jeff.w.evans,Jeff Evans
+nbeyer,Nathan Beyer
+ianribas,Ian Ribas
+kalradeepak,Deepak
+peterchang,peter chang
+hendrikmuhs,Hendrik Muhs
+brion@pobox.com,Brion Vibber
+treyhyde,Trey Hyde
+danblack,Daniel Black
+bmesser,Bernhard Messer
+cristian.vat,Cristian Vat
+anthonyu,Anthony Urso
+Thomas Kappler,Thomas Kappler
+kphayen,Kevin Hayen
+cwinkler,Christian Winkler
+deansg,Dean Gurvitz
+aheinz_lulu,Adam Heinz
+robert.onslow@8newsquare.co.uk,robert.onslow
+zhangchao.es,zhangchao.es
+maosuhan,Suhan Mao
+sunzheng04,Zhenglin Sun
+ecerulm,Ruben Laguna
+dquaroni@openratings.com,Daniel Quaroni
+myusername8,Nándor Mátravölgyi
+kanarsky,Alexander Kanarsky
+pifpafpuf@gmx.de,Harald Kirsch
+rodrigotrujillo,Rodrigo Trujillo
+joaoplm,João Paulo Lemes Machado
+obecker,Oliver Becker
+xcchen@gmail.com,Xue-Chun
+fizx,Kyle Maxwell
+aberdeen61,Dan Climan
+patrek,Patrick Turcotte
+tom_s4t,Thomas Hoffmann
+apanimesh061,Animesh Pandey
+renes,Rene Schwietzke
+PraveenNishchal,Praveen Nishchal
+systect,Holger Bruch
+jeng832,Jehyun Lee
+luca.stancaqpiano,Luca Stancapiano
+rch,Ryan Hill
+tim-lebedkov@upk.de,Tim Lebedkov
+irvingzhang,Xin-Chun Zhang
+kamstrup,Mikkel Kamstrup Erlandsen
+philippn,Philipp Nanz
+rvega,Rodrigo Vega
+adrian.tarau,Adrian Tarau
+nikhil500,Nikhil Chhaochharia
+terje_eggestad,Terje Eggestad
+thushara,thushara wijeratna
+akitta,Akos Kitta
+pbarna,Peter Barna
+tilman.giese@gmx.de,Tilman Giese
+pickypg,Chris Earle
+lakhani.ajay,Ajay Lakhani
+ippei,Ippei UKAI
+JeromeP,Jerome Prinet
+modassar,Modassar Ather
+infodroids,Jigar Shah
+haozhong,Hao Zhong
+nezda,Luke Nezda
+osavrasov,Dr Oleg Savrasov
+rpedela,Ryan Pedela
+andrew_duffy,Andrew Duffy
+bitbrunch,Shahan Khatchadourian
+yahootintin-lucene@yahoo.com,Reece (YT)
+lifove,JC
+rragno,Robert Ragno
+kaineci,kaineci
+ankon,Andreas Kohn
+sarowe@syr.edu,Use account "steve_rowe" instead
+charles.sanders@gxs.com,Charles Sanders
+alexklibisz,Alex Klibisz
+ivandimitrovvasile,Ivan Dimitrov Vasilev
+gnandre,gitesh
+ebradshaw,Elliott Bradshaw
+Gueust,Jean-Baptiste Lespiau
+john@rte.ie,John Moylan
+derkaas,Kelsey Francis
+l0co,l0co
+lukhnos,Lukhnos Liu
+viniciusbarros,Vinicius Barros
+jej2003,Jamie Johnson
+peathal,Peter Karich
+lmenezes,Leonardo Menezes
+smerchek,Scott Smerchek
+hdeadman,Hal Deadman
+nightrider,Peter Schäfer
+ymatsuda,Yasuhiro Matsuda
+dpsharma,Deepika Sharma
+spmason,Steve Mason
+jwartes,Jeff Wartes
+gmaloon,Graham Maloon
+ken.mccracken,Ken McCracken
+siberski,Wolf Siberski
+Honor-Jeremy,Jeremy Liu
+kuhn@fg.cz,Jiri Kuhn
+truemped,Daniel Truemper
+mpoindexter,Michael Poindexter
+simon.rosenthal,Simon Rosenthal
+pleira,Pablo Pita Leira
+nidaley,Nigel Daley
+ingorenner,Ingo Renner
+amake,Aaron Madlon-Kay
+vivash,vivek
+mulugetam,Mulugeta Mammo
+ollik1,Olli Kuonanoja
+jiangtao,hu
+henningandersen,Henning Andersen
+tejas.jethva,Tejas Jethva
+neunand,Andreas Neumann
+gsmet,Guillaume Smet
+mdodsworth@salesforce.com,Michael Dodsworth
+astubbs,Antony Stubbs
+ppujari,Pradeep
+karsten-solr,Karsten R.
+a2tirb,britta weber
+mkrio,Matthias Krueger
+bokkie,Chris Geeringh
+michi,Michael Wechner
+miles@runtime-collective.com,Miles Barr
+ahempel@atlassian.com,Adrian Hempel
+gstamp,Glen Stampoultzis
+shi,Rudi Quark
+ab@getopt.org,Andrzej Bialecki
+lujia35,Luke
+cemerick,Chas Emerick
+eleanor,Eleanor Joslin
+martijn,Martijn van Groningen
+dave.sparks@teamware.co.uk,Dave Sparks
+pigo,Pierre Gossé
+max@osua.de,Maxim Patramanskij
+jgq2008303393,Guoqiang Jiang
+shivenderd,Shivender Devarakonda
+is_maximum,Mohammad Norouzi
+survivant,Sebastien Dionne
+MathBunny,Horatiu Lazu
+alexeyk,Alexey Kudinov
+joe hou,fang hou
+krystian,Krystian Nowak
+jvstein,Jeff Stein
+sheringeorge7,sherin george
+pl.perron,Pierre-Luc Perron
+jerry.davis@wwt.com,Jerry Davis
+mchaput,Matt Chaput
+fulmicoton,Paul Masurel
+ivan.s,Ivan.S
+rubenql,Ruben Q L
+drjz,Junte Zhang
+jagsisingh,Jagmohan Singh
+dmitry.lihachev,Dmitry Lihachev
+openteam,OpenTeam.ru
+luke@languagecomputer.com,Luke
+raanan,Raanan Mintz
+ishansri,Ishan Sri
+kburjack,Kai Burjack
+hwellmann,Harald Wellmann
+torao,Torao Takami
+fred.yu@xtra.co.nz,Fred
+anusha305,Anusha Rao
+JeroenB,Jeroen Baas
+martin3000,dingjin
+simon.endele,Simon Endele
+alexistp,Alexis Torres Paderewski
+sleshJdev,Yauheni Putsykovich
+gforget,Gui Forget
+dazoot@gmail.com,Catalin Constantin
+jvassev,Julian Vassev
+hsbauer,Scott Bauer
+imgpulak,Pulak Ghosh
+dror@matal.com,Dror Matalon
+gonzalezcarlos2,Carlos González-Cadenas
+chris.gioran,Chris Gioran
+ldb,Vadim Kisselmann
+hwang,Hsiu Wang
+zinger,Matan Zinger
+oldskoolmark,Mark Rosenberg
+lukeforehand,Luke Forehand
+d.allsopp@signal.qinetiq.com,David Allsopp
+clemensdev,Clemens Wyss
+ivanp,Ivan Petrovic
+ralani@etact.com.sg,ralani
+vamsee,Vamsee K. Yarlagadda
+jcuzens,Jarrod Cuzens
+gegez@wp.pl,legez
+alesj,Ales Justin
+jlambert,Jason Lambert
+rmajewski,Rafal Majewski
+changchun,changchun huang
+emir.arnautovic,Emir Arnautovic
+dustinday,John Doe
+swarnendubiswas,Swarnendu Biswas
+smlv,SML
+shdwfeather,Yubin Kim
+tanguy,Tanguy Moal
+Muler,Muler
+senthilu,senthil nathan
+tsmatphanhtoken,Nguyễn Tiến sỹ
+unruledboy@hotmail.com,Unruled Boy
+jcruanes,Jorge Cruanes
+f1list,Tzvika Barenholz
+thrykol,Shane
+jsalvata@apache.org,Jordi Salvat i Alabart
+spmiller,Stuart
+djotanov,Dragan Jotanovic
+knsathya@hotmail.com,Sathya K
+sor,Christian Stein
+rfscholte,Robert Scholte
+costin.leau,Costin Leau
+xunjian,xunjian
+jzwiener,Jakob Zwiener
+jpendleton,Justus Pendleton
+christianziech,Christian Ziech
+danielbigham,Daniel Bigham
+dkrzemin,pirxpilot
+joanitad,Joanita Dsouza
+philipreimer,Philip Reimer
+mgrigorov,Martin Tzvetanov Grigorov
+xetorthio,Jonathan Leibiusky
+mjlawley,Michael Lawley
+waltersbox,Walter Ferrara
+brianm,Brian McCallister
+psemeniuk,Petro Semeniuk
+schlosna,David Schlosnagle
+dotteben,Ben Dotte
+d.de.wit,Daan de Wit
+chengpohi,chengpohi
+markus-klose,Markus Klose
+mmendelson@intowndenver.com,Michael Mendelson
+andyhauser,Andreas Hauser
+morr@xorr.net,Mark Orr
+selimnadi,Selim Nadi
+h-aro,Petr Nekvinda
+pkammer@endeavors.com,Peter Kammer
+jigaronline,Jigar Shah
+mturk@apache.org,Mladen Turk
+viobade,viobade
+jhasenbe,Josef
+kzwang,Kevin Wang
+scolastique,Christophe Bégot
+amirkibbar,Amir Kibbar
+julio.melo@gmail.com,Júlio César e Melo
+duriku,Juraj Kucera
+arteam,Artem Prigoda
+caviler,caviler
+lpriima,Lev Priima
+bmandal,Balmukund Mandal
+slav-777,Slav Boleslawski
+waiwong,Wai Wong
+dinesh@sasoft.com.my,Dinesh Gupta
+vcl00e,Vincent Li
+chedong@yeah.net,Che, Dong
+jshin@jtan.com,Jungshik Shin
+mads1980,Manuel Dominguez Sarmiento
+nyxz,Nikolay Georgiev
+pfoster,Paul Foster
+yankang,Yankang Jiang
+profimedia,Profimedia
+dlants,Denis Lantsman
+svamann,Sven Amann
+kbkreddy,Bala Kolla
+AllenYang,杨维云
+mhugo,Hugo Mercier
+ivyshnevskyi,Iurii Vyshnevskyi
+nonrenewable,Antoniya Statelova
+philip.searle,Philip Searle
+dblock,Daniel Doubrovkine
+swami,Sagar Patil
+martin.ruckli,Martin Ruckli
+upthewaterspout,Dan Smith
+tdv@part.net,Todd D. VanderVeen
+paulnilsson,Paul Nilsson
+anthony.signoret,Anthony Signoret
+acm,Arjen
+cthomas@fls-inc.com,Cory Thomas
+smaugg@gmx.net,AndrÃ© Wolf
+dpgove,Dennis Gove
+stefan.franz@drv-bw.de,Stefan Franz
+pkiraly,Király Péter
+veena.channagouda,Veena Channagouda
+david.bohl@tfp.com,david.bohl
+fpientka,fpientka
+wunan23,wunan23
+lpereir4,Lucien Pereira
+jrichards22,Jim Richards
+thibaulth.,Thibault Houel
+micrenda,Michele Renda
+jhartman,Joshua Hartman
+rparekh,Rahul Parekh
+aahmed,Ali Ahmed
+zaphod@byzantine.no,Alex Staubo
+jvv,Jonas van Vliet
+Brain2000,Brian Coverstone
+cpinotossi@web.de,Christian Pino Tossi
+lakshman.peta,lakshman
+hc56@cornell.edu,Herman Chen
+dohykim,donghyun Kim
+hadasrv,Hadas Raviv
+mogui,Niko Usai
+martint,Martin Traverso
+javasmash,Xibin Zeng
+johann_beessip,Johann Abraham
+sheidrich,Stefan Heidrich
+ckoenig42,Chris Koenig
+stask,Stas Krichevsky
+reyes@charabia.net,Rodrigo Reyes
+wingerz,Wing Yung
+adhotre@ctepl.com,Anil Dhotre
+JaosnAr,Jason R Robinson
+davinci79,Vincent van Beveren
+gloewy,Guy Loewy
+boris@alum.mit.edu,Boris Goldowsky
+davishmcclurg,David Harsha
+mirza,Mirza Hadzic
+zhanlijun,zhanlijun
+hindikaynen,Khindikaynen Aleksey
+cesar.rodriguez,Cesar Rodriguez
+v_sitnikova,Vasilisa Sitnikova
+c2,Shradha Shankar
+cwible,Cullin Wible
+cquezel,Claude Quézel
+lee@grantadesign.com,Lee Mallabone
+vigna,Sebastiano Vigna
+Ananth2802,Anantha Krishnan Mahalingam
+psomogyi,Peter Somogyi
+pinker,Xiaoping Gao
+mingfai,Mingfai Ma
+raz71abb6,raz71abb6
+Julm,Julien Martin
+sbailliez@apache.org,Stephane Bailliez
+passerbya,wangzhenghang
+rgiles,R Giles
+ohummel,Oliver Hummel
+liam1965,William Johnson
+einachim,Achim Heiland
+eirbjo,Eirik Bjorsnos
+hari.mailinglists@gmail.com,Hari Kodungallur
+renanpto,Renan Pedro Terra de Oliveira
+edans.sandes,Edans Sandes
+mendonca.isabel,Isabel Mendonca
+cstamas,Tamás Cservenák
+fix@idiom.com,Eric Fixler
+karstendausb,Karsten Dello
+fyr|,f
+mbarr,Miles Barr
+kevinoliver@mac.com,Kevin Oliver
+mrkm4ntr,Shintaro Murakami
+selah,Chris Russell
+jaspervanveghel,Jasper van Veghel
+ashwin.jayaprakash,Ashwin Jayaprakash
+daveseltzer,Dave Seltzer
+dlade,Danny Lade
+adpalmer,Andrew Palmer
+aqshey,Akshay Patil
+xiaoheipangzi,lujie
+crspan,Charlie Zhao
+hfang,Hui Fang
+huifang,Hui Fang
+scottsch,Scott Schneider
+sunnyk,Sunny Khatri
+ravikumar.govindarajan,Ravikumar
+waynexin,Wayne Xin
+edovne,Yegor Dovganich
+oshimat@gmail.com,Oshima
+rowanto,Rowanto Rowanto
+daubman,Aaron Daubman
+mmastrac,Matthew Mastracci
+mjkim0324,M Kim
+tejkiransharma,Tej Kiran Sharma
+sheecegardezi,Syed Sheece Raza Gardezi
+ivan.mamontov,Ivan Mamontov
+Dmitry Popov,Dmitry Popov
+tonicava,Octavian Mocanu
+gezapeti,Gézapeti
+sidgate,Siddharth Gargate
+brsuribabu,Suri Babu B
+bizhan,Pasha Bizhan
+adupriez,Alexandre Dupriez
+micky.zf,micky.zf
+escowles@ucsd.edu,Esme Cowles
+marc.cull@labvelocity.com,marc cull
+dominicdsouza,Dominic Dsouza
+a_zelin,Alexey Zelin
+mschipperheyn,marc schipperheyn
+ertiop93,Ertio Lew
+leblowl,Lucas Leblow
+apache.org@scottyallen.com,Scotty Allen
+hans.hjelm@ling.su.se,Hans Hjelm
+jdornseifer,Jan Dornseifer
+ptaylor999,Peter Taylor
+sekumar,Selva Kumar
+osbornk0,Kevin Osborn
+tomsolr,Tom Hill
+xiaozheng.ma@redwood.com,Xiaozheng Ma
+sanikumar21@gmail.com,sani  kumar
+kaihe,kaihe
+Lai_Ding,AllenL
+syonekura,Sebastian Yonekura Baeza
+Gunachandra,Gunachandra
+ibolotin,Igor Bolotin
+dearing,Greg Dearing
+Chalasani,Kranthi
+mayras,Alexander Stepanov
+stephlag,Stephan Lagraulet
+m1@snyder-haye.com,Martin Haye
+aponomarenko,Andrey Ponomarenko
+dhananjaysah,Dhananjay Kumar
+bdelacretaz,Bertrand Delacretaz
+stng@theculprit.com,Stanford Ng
+moritan,ROULLAND Bruno
+hadasra,hadas raviv
+carrie,Carrie Chen
+judovana,jiri vanek
+giovanni.cuccu,Giovanni Cuccu
+realviacauchy,Jessica Bonnie
+kartg,Kartik Ganesh
+gnix infosoft,gnix infosoft
+srose,Stuart Rose
+ArchanaAM,Archana A M
+Bruno86,Bruno CAILLAUD
+raintung,Raintung Li
+bbindra,Surinder Pal Singh Bindra
+talsteier,tal steier
+poulejapon,Paul Masurel
+madhvi,madhvi gupta
+snb,Nick Barkas
+bneelima84,Neelima
+bw2,Ben Weisburd
+scholzb-hb,Bernhard Scholz
+djptek,Dominic Page
+reuschling,Christian Reuschling
+moogie,moogie
+djocas,Dainius Jocas
+jhump,Joshua Humphries
+bra@fsn.hu,Attila Nagy
+feigao@sohu-inc.com,gaofei
+rimi,rimi
+mitja.lenic,Mitja Lenič
+skaffman,Kenny MacLeod
+issues.apache.org@chasmcity.com,Kenny MacLeod
+pierre.van.rooden@omroep.nl,pierre.van.rooden
+alisonatwork,Alison Winters
+mdubey,Manish Dubey
+krichards,Kevin Richards
+rickmasters,Rick Masters
+tombombad,Michael Böckling
+jfpascual@isotrol.com,Juan Francisco Pascual
+radu0gheorghe,Radu Gheorghe
+dcroley,David Croley
+yankees26an@gmail.com,Stanislav Palatnik
+vkirilchuk,Vadim Kirilchuk
+massimoferrario,Massimo Ferrario
+aguther,Andreas Guther
+andreaskohn,andreaskohn
+kostya_knik@yahoo.com,kostya
+nmeisels,Nathan Meisels
+asgeirf,Asgeir Frimannsson
+jdpatterson,John Patterson
+fwiffo,Joey Echeverria
+vlivanov,Vladimir Ivanov
+henss,Joerg Henss
+moebius,Florian Waltersdorfer
+ivan.rozhnov,Ivan Rozhnov
+pborgerm,Paul Borgermans
+george.papas,George Papas
+EqualToJake,Jacob Graves
+simpleBread,Xu Zhang
+parmeet.singh262@gmail.com,Parmeet Singh Sachdeva
+eliaporciani,Elia Porciani
+rpeddacama,Rupendra Peddacama
+kmheibel,Kristin Heibel
+nvt,Nigel V Thomas
+rmelisson,Remi Melisson
+mkristensson,Mark Kristensson
+pbruski_,Przemek Bruski
+csk_,Clemens Stukenbrock
+guinsu,Tim Patton
+Paul Pazderski,Paul Pazderski
+simpatico,Gabriele Kahlout
+amcy,Anthony Yeracaris
+mackncheesiest,Joshua Mack
+rinka,Rinka Singh
+qwerty123,vikash
+jeffrey.sanford,Jeffrey Sanford
+fred_maranhao@yahoo.com.br,Fred U MaranhÃ£o
+xinz,Xin Zheng
+mjhugo,Mike Hugo
+mharhen,Michael Harhen
+prolog_tutor@gmx.de,prolog_tutor
+roy.donasco@dhl.com,roy donasco
+jakmcabne,Jeremy Meyer
+cowtowncoder,Tatu Saloranta
+MarkusG,Markus Gietzen
+mbellew,Matthew Bellew
+phax,Philip Helger
+magnus12345678@gmail.com,Magnus
+lajos.kesik@gmail.com,Lajos Kesik
+chandanrrk,Chandan Raj Rupakheti
+shamirwasia,Sorabh Hamirwasia
+konstantin.nazarenkov,Konstantin Nazarenkov
+ianlea,Ian Lea
+hardy,Hardy Ferentschik
+gshackles,Greg Shackles
+mbystryantsev,Mikhail Bystryantsev
+jigarym@gmail.com,Jigar Mehta
+parvaz,itai sason
+christopherball,Christopher Ball
+PROgrm_JARvis,Petr Portnov
+nickptar,Nick Tarleton
+adam.laczynski,Adam Łączyński
+ruslan.torobaev,Ruslan Torobaev
+emetsger,Elliot Metsger
+a.kuckartz@ping.de,Andreas Kuckartz
+sven.duzont@keljob.com,Sven Duzont
+bohlgod@gmail.com,David Bohl
+mamoabeng,Manuel Amoabeng
+snwiem,Sebastian Wiemer
+torindan,Torin Danil
+elijah.epifanov@gmail.com,Ilya Epifanov
+dcliman,Dan Climan
+satoshi.kato,SatoshiKato
+miyaharas,miyaharas
+rokirch,Robert Kirchgessner (JIRA)
+nzamosenchuk,Nikolay Zamosenchuk
+hatim hakeel,Hatim Hakeel
+Riis,Torben Riis
+ykats,Yury Kats
+noreply@nabble.com,Nabble
+bitscorpion,Johann Höchtl
+fx.bonnet,Francois-Xavier Bonnet
+jgibson,John Gibson
+rahul290484,Rahul Babulal
+okkeklein,Okke Klein
+aquaglia,Angelo Quaglia
+solrize,solrize
+nick.west@intercea.co.uk,Nick West
+jonstewart,Jon Stewart
+stephane.campinas@gmail.com,Stéphane Campinas
+jiangyaokai,Yaokai Jiang
+andreas.presthammer,Andreas Presthammer
+kyriak,Kyriakos Karenos
+moscht,Michel Conrad
+saschamarkus,Sascha Markus
+Jushiro,yubinglei
+mseitz,Martin Seitz
+iwesp,Ingomar Wesp
+rahearn,Ryan Ahearn
+vstrugatsky,Vladimir Strugatsky
+mikichi,Michael Solomon
+jonhoag,Jonathan Hoag
+andreas_kostyrka,Andreas Kostyrka
+AppChecker,AppChecker
+leon@level7.ro,leon
+vnbiggs,Ivan Biggs
+bugs@goofrider.imap.cc,Jeffrey Chan
+jons@wrq.com,Jon Schuster
+rviper,Robert Starzer
+chengas123,Ben McCann
+nick,Nick Burch
+gro,Rafał Kuć
+haschart,Robert Haschart
+jamietaylor,Jamie
+docware@hotmail.com,Michael Südkamp
+joe1111,Joe
+filipncs,Filip Svendsen
+paulmerlin,Paul Merlin
+chrislusf@yahoo.com,Chris Lu
+stephen_a100@hotmail.com,A Stephen
+rahul196452@gmail.com,Rahul Goswami
+jasonpolites,Jason Polites
+hossman_lucene@fucit.org,Chris Hostetter (Unused)
+btltm818,Bill McBride
+btltm818@yahoo.com,Bill
+css145hs,Derek DeMarco
+marschall,Philippe Marschall
+chy1013m1,alex
+thierry.guerin@prima-solutions.com,Thierry Guerin
+schoenm@earthlink.net,Michael Schoen
+iangrainger,Ian Grainger
+jpardos,J Pardos
+pkimber,Patrick Kimber
+t.costermans,Tim Costermans
+tcostermans,Tim Costermans
+vstoto,Vilaythong Southavilay
+ochafik,Olivier Chafik
+joerg@j-hohwiller.de,Jörg Hohwiller
+larhamel,Larry Hamel
+pcurren,Paul Curren
+nekulin,Nikolai
+brendanh,Brendan Humphreys
+soujanya,Soujanya
+rcmuir ,Robert Muir
+nativepol,Native Policeman
+atbagga,Atul
+rstocker,Robin Stocker
+jennywithgun,Huajing Li
+yeliz,Yeliz Eseryel
+ts01,venkat rangan
+mattinger,Matthew P. Inger
+michaelryan,Michael Ryan
+dnalneh,Henrik Hertel
+zhuming,Ming Zhu
+brianmeidell,Brian Meidell
+nick.kirsch,Nick Kirsch
+cashcrop,Wendy Feng
+vdm,Vincent Murphy
+sqisher,Daniel Bechler
+alders,Alexander Sofronov
+jlmaty,Matyjaszczyk
+infrabot,#asfinfra Bot
+slomkowski,Michał Słomkowski
+songguo,Guo Song
+gregharris73,Greg Harris
+ningli@us.ibm.com,Ning Li
+jkassis,Jeremy F. Kassis
+jasonhusong,Jason Rutherglen
+sewe,Andreas Sewe
+uygaryuzsuren,uygar yuzsuren
+rajeessh,Rajesh Srinivasan
+skybert,Torstein Krause Johansen
+iksnalybok,Iksnalybok
+lachu,Lakshmanan
+jbrush@migrantprogrammer.com,Jeffery Brush
+ralph@massrelevance.com,Ralph Tice
+ralph.tice,Ralph Tice
+wrh2,Ryan Holliday
+fsanchez,Felipe Sánchez Martínez
+unhammer,Kevin Brubeck Unhammer
+apsmith,Arthur Smith
+odony,Olivier Dony
+tgar,Tim Armstrong
+spaceflysky@163.com,space fly
+peleteiro,Jose Peleteiro
+jpggasi,Juan Pedro
+twdsilva@gmail.com,Thomas D'Silva
+viruslviv,Zenoviy Veres
+dougsale,Doug Sale
+antoniomartinez,Antonio Martinez
+klawson88,Kevin Lawson
+csuresh,Suresh Chandran
+Rahmani,Rayane
+belkale,Naveen Belkale
+tflander,Todd Flanders
+jeffreymorlan,Jeffrey Morlan
+willjohnson3,Will Johnson
+shyamvs1001,Shyam V S
+lben1992,Benzahia Lakhdar
+ryadh,Ryadh Dahimene
+alexb,Alex Baranau
+gmistic,Ion Badita
+samphan,Samphan Raruenrom
+arthit,Arthit Suriyawongkul
+reis,Rei Shapira
+tero@favorin.com,Tero Favorin
+iekpo,Israel Ekpo
+thunder_byy,Bao Yang Yang
+mlambert@aseedge.com,Michael Lambert
+m.wagner@blue-orange.de,Michael Wagner
+rvestal@austin.rr.com,Rick Vestal
+Broers,Selene Broers
+simon lorenz,Simon Lorenz
+bartatamas,Barta Tamás
+neilireson,Neil Ireson
+jiajun,Zhu JiaJun
+gpaimla,Gert Morten Paimla
+rkhmelichek,Roman Khmelichek
+mbonaci,Marko Bonaci
+yinlin,yin Lin
+mdissel,Marco Dissel
+andrew.newman,Andrew Newman
+kysnail,kysnail
+gstein@gmail.com,Greg Stein
+gstein,Greg Stein
+harini.raghavan@insideview.com,harini.raghavan@insideview.com
+epitschke,Elmar Pitschke
+paramsethi,Param Sethi
+jeremy.bolanos,Jeremy Bolanos
+krishan1390,Krishan Goyal
+Baik,Jason Baik
+cliontos,Christos Liontos
+ZhongHua,ZhongHua Wu
+isoboroff,Ian Soboroff
+kfc,Kåre Fiedler Christiansen
+appler@gmail.com,Cheolgoo Kang
+mlossos,Michael Lossos
+lsdfkj,Mikhail
+Solodin,Andrei
+katinka,Katrin E.
+tinkler@thinkmap.com,Marc Tinkler
+vbychkoviak@i-hypergrid.com,Volodymyr Bychkoviak
+stefan.wachter@gmx.de,Stefan Wachter
+mumrah,David Arthur
+saar32,Saar Carmi
+aguenther@collab.net,Andreas Guenther
+yoursoft,YourSoft
+laura-dietz,Laura Dietz
+chris.todd@comcast.net,Chris Todd
+uwe.stahl@entory.com,Uwe Stahl
+hossman@fucit.org,Chris Hostetter (Unused)
+hackerwin7,hackerwin7
+hrdxwandg,hrdxwandg
+timbrooks,Tim Brooks
+r_n7,Ritesh Nigam
+gdeconto,Gerald DeConto
+fedenkov,Ivan Fedenkov
+Xibao,Xibao
+hanafey,Mike Hanafey
+nick.chervov,Nick Chervov
+b_andras,Baló András
+maciej.zasada,Maciej Zasada
+bschneeman@yahoo.com,bschneeman
+webzhu,朱文彬
+crice,Colm Rice
+prashantspol,Prashant Pol
+timbrennan,Tim Brennan
+mpichler,Michael Pichler
+kozaczynski,Wojtek Kozaczynski
+pwoodward@cncdsl.com,Porter Woodward
+cwilkes-lucene@ladro.com,Chris Wilkes
+roshan@teamqsi.com,Roshan Shrestha
+nbhatnagar@sapient.com,Neelam Bhatnagar
+mwhipple,Matt Whipple
+mario@ops.co.at,Mario Ivankovits
+vintz,Vincent Le Maout
+mbennett,Mark Bennett
+nitzan.shaked,Nitzan Shaked
+vidda,David Herrera
+stefan.klein,Stefan Klein
+jarno.elovirta@nokia.com,Jarno Elovirta
+Brier,Tim Brier
+joshbronson,Josh Bronson
+matias,Matias Holte
+Pheelbert,Alexandre Philbert
+jameswdumay,James William Dumay
+brettporter,Brett Porter
+anoopamz,anoop
+cpilsworth,Chris Pilsworth
+alejandro.villa,Alejandro
+claudelepere,Claude Lepère
+jhager@gmail.com,Jonathan Hager
+mdoar,Matt Doar
+fmar,Fernando Martins
+fern,Fernando Padilla
+ktopping,kieran
+antonyscerri,Antony Scerri
+probakowski,Przemko Robakowski
+cbowditch,Chris Bowditch
+maahi333,Mahesh
+koehler@oio.de,Kristian Köhler
+maa,M Alexander
+schmanu,Manuel Gellfart
+smarjan,Slobodan Marjanovic
+mike.streeton@ardentia.co.uk,mike streeton
+jnystad,Jørgen Nystad
+blaingu,Guillaume Blain
+feristhia,Feris
+zolgatron,Nikhil Gupta
+dreampk00,Won Jonghoon
+andy.tran,Andy Tran
+burton@apache.org,c2ru048
+ck@rrzn.uni-hannover.de,Christian KohlschÃ¼tter
+ryandaum,Ryan Daum
+ranjitots,ranjit kumar
+boris-petrov,Boris Petrov
+markswanson,Mark Swanson
+halu,Hans Lund
+gsteff,Greg Steffensen
+jyoung,Jonathan Young
+mdossantos,Mark Dos Santos
+tigerchen,Michael Gaber
+Nayana,Nayana Thorat
+Tagar,Ruslan Dautkhanov
+edwinyeozl,Edwin Yeo Zheng Lin
+nolanlawson,Nolan Lawson
+devang.panchal,Devang Panchal
+hilly.zhu@gmail.com,hilly
+manuel lenormand,Manuel Lenormand
+thecaptain1977,Keith Morgan
+mbien,Michael Bien
+stoney,Frank Steinmann
+topbit,Topbit Du
+jminard,Jayson Minard
+jirajira,Eric James
+cdanninger,Christian Danninger
+preetam,Preetam Rao
+vyzivus,Martin Vysny
+bkazar,BARIS KAZAR
+jeremynovey,Jeremy Novey
+DHAVER0313,Dustin Haver
+todaylxp,luo
+kaktuchakarabati,Kaktu Chakarabati
+aungmaw,AM
+xiaohuiliu,xiaohuiLiu
+popeyelin,Yueyu Lin
+jason.nacional,Jason Nacional
+Gallifreii,Mark Peck 
+chubbard,Charlie Hubbard
+ken@kensystem.com,Ken Johanson
+enis,Enis Soztutar
+samj1912,Sambhav Kothari
+olek,Ole Kværnø
+arvind.singh1808@gmail.com,Arvind
+mozer,Peter Backlund
+gjc,George J. Carrette
+baiyun@yahoo.com,Carroll
+ifonly@yeah.net,ifonly
+emetsds,Dmitry Emets
+yangxq,Terry Yang
+icemank,Sunil Kamath
+przemosz,Przemysław Szeremiota
+shyamal,Shyamal Prasad
+wang_feicheng,WangFeiCheng
+vamshi,Vamshi Vijay Nakkirtha
+lwhay,Wenhai Li
+ariel_lieberman@hotmail.com,Ariel Lieberman
+Lohhari,Vesa Pirila
+lix511,Xiang Li
+ahubold,Andreas Hubold
+d.venturini@intersistemi.it,Davide Venturini
+timretout,Tim Retout
+JoeZ,Joe Szymanski
+aqua_indian,Ashish Datta
+boxbe-notifications@boxbe.com,boxbe-notifications@boxbe.com
+jerry.russell@worldwideweave.com,Jerry Russell
+alexliu68,Alex Liu
+cbartolo,Colin Bartolome
+jyoti609,jyoti Tiwari
+grahamp,Graham P
+the_alchemist,The Alchemist
+tal@zapta.com,Tal Dayan
+brian@interscales.com,Brian Hanafee
+lhelper,Kerang Lv
+ahudson,Andrew Hudson
+matt@codemonkeyconsultancy.net,Matthew Denner
+rrao@alterpoint.com,Ravindra Rao
+peter.schaefer@healyhudson.com,Peter SchÃ¤fer
+afilimonov,Andrei Filimonov
+barakatx2,Barakat Barakat
+steveneo,steve neo
+wkaichan,Kai Chan
+apisu,Aurelien PISU
+aaleev,Aleksey Aleev
+adamh,Adam Hiatt
+doug@dougandalli.com,Doug Kirk
+aviran,Aviran
+p.witte@cs.unimaas.nl,Puk Witte
+Dhwanit,Dhwanit Gupta
+salyh,Hendrik Saly
+Oyeme,Andrejs Aleksejevs
+werder,Andrey Kudryavtsev
+ipojman@jmlafferty.com,ian pojman
+yury_hohin,Yury Hohin
+larsrc,Lars Clausen
+aisotton,Aaron Isotton
+rene.scheibe,Rene Scheibe
+denimorim,Denilson Amorim
+jnorton@yellowbrix.com,James Norton
+ajay bhat,Ajay Bhat
+pru30,Praveen Nishchal
+tibounig,Tobias Ibounig
+wicked1099,Sean Torres
+gcooney,Geoff Cooney
+sbailliez,Stephane Bailliez
+lzap,Lukas Zapletal
+mr_gambal,Dmytro Hambal
+dchaplinsky,Dmitry Chaplinsky
+a.schild,Andre Schild
+a.schild@neatech.ch,Andre Schild
+kyrill007,Kyrill Alyoshin
+cdarroch,Chris Darroch
+joao_fonseca,João Fonseca
+lcs,Martin Blom
+ramesh.b.d,Ramesh
+shyam.remella,Shyam
+rocco.verhoef,Rocco Verhoef
+rwk,Bob Kerns
+konrad@xtramind.com,Karsten Konrad
+mintern,Brandon Mintern
+jeremyc,Jeremy Calvert
+mnassif20,Michael W. Nassif
+davidvdd,David vandendriessche
+benjismith,Benji Smith
+nminami,Naoto Minami
+philippe@camellia,Philippe
+etienno,Etienne
+v.damore@gmail.com,Vincenzo D'Amore
+mjuarez,mjuarez
+pcc,paul constantinides
+jianjun.yue,yuejianjun
+wsalembi,Willem Salembier
+nalle@ymail.de,M. Reinsch
+malco@claranet.de,Gerhard Schwarz
+originalsosa,Ricky Pritchett
+budili,Tim A. 
+sachin_burange@persistent.co.in,sachin
+glens@apache.org,Glen Stampoultzis
+thulasiram333,Thulasi Ram Naidu P
+richter@hrz.uni-essen.de,richter
+Kayne,Kayne Wu
+kbohling,Kirby Bohling
+ildella,Daniele
+eschnepel,Enrico Schnepel
+hevalazizoglu,Heval Azizoglu
+paulward24,Paul Ward
+giltene,Gil Tene
+dhuang,Da Huang
+michael.goddard,Michael Goddard
+salman741,Salman Akram
+jsoles@etranslate.com,JD
+joadams27,John Adams
+mpdreamz,Martijn Laarman
+locklevels,Lock Levels
+sangwhan,Sangwhan Moon
+nitiraj,Nitiraj Rathore
+Daiki Tsuzuku,Daiki Tsuzuku
+alan@collison.net,alan
+chrislusf,Chris Lu
+a_wronski@gazeta.pl,Artur Wronski
+cornuz,Roberto Cornacchia
+msauvee,Mickaël Sauvée
+madpickles,James Pine
+mar-kolya,Nikolay Martynov
+christ,Chris Thistlethwaite
+koenhandekyn,koen handekyn
+wenbin.zhu,wenbin.zhu
+yannianmu,yannianmu
+dominik@consol.pl,Dominik Balos
+guifengleaf@gmail.com,Feng Gui
+tsegaran,Toby Segaran
+vaiju1981,Vaijanath N. Rao
+climbingrose,Cuong Hoang
+soap@263.net,javabug
+Deltharis,Michał Torba
+dtertman,Dan Ertman
+christian.mallwitz@xbridge.com,Christian Mallwitz
+dxl360,Duan Li
+euske,Yusuke Shinyama
+jeroens,Jeroen Steggink
+jeffyang,Jeffrey Yang
+dgoldfarb,David Goldfarb
+nickf,Nick Faiz
+snowhow,Tushar B
+yo@yos.biz,Joachim Schreiber
+afalca,Alex Falca
+proyal,Peter A Royal Jr.
+hunts,Hunts Chen
+adamestrada,Adam Estrada
+pramirez,Paul Ramirez
+psztoch,Przemyslaw Sztoch
+edudar,Eduard Dudar
+nikiparmar,Niki
+Marvin Justice,Marvin Justice
+zgantner,Zeno Gantner
+kreiger,Christoffer Hammarström
+peternorrhall@yahoo.se,Peter Norrhall
+kazanture,Emre Bayram
+bkazez,Ben Kazez
+jmb236,Joel Barry
+kirigirisu,Russell A Brown
+gvkraj23,vijaykumarraja.grandhi
+joes,Joe Schaefer
+pakozdi.tibor@freemail.hu,Pakozdi Tibor
+mbalekundri,Rohit Balekundri
+damianpawski,Damian Pawski
+oferfort,ofer fort
+rzotter,Robert Zotter
+silvaran,Scott Van Wart
+asimatov,Alex Simatov
+szott,Sascha Szott
+ledahulevogyre,David L
+tbecker,Thomas Becker
+dafna,Dafna Sheinwald
+jdemler,Jakob Demler
+mbaroukh,Mike Baroukh
+kevinconaway,Kevin Conaway
+jhakim,jawaid hakim
+kathleen.hilston@snapon.com,Kathleen Hilston
+Sensor66,Martin Schoenmakers
+nithril,Nicolas Labrot
+svar,Sovanramy VAR
+camilojd,Camilo Díaz Repka
+maxpsq,Massimo Pasquini
+alexeyline,Alexey Kutin
+hhamid,Hafiz M Hamid
+ariscris,Maricris Villareal
+j.tervoorde@home.nl,Jeroen ter Voorde
+bnicolotti,B.Nicolotti
+Emskiq,Emiliyan Sinigerov
+mck,Michael Semb Wever
+dathanasiou,Dimitrios Athanasiou
+richard.marr,Richard Marr
+greggny3,Gregg Donovan
+asm,Andrew Morrison
+kganong,Ken Ganong
+erich.schubert,Erich Schubert
+thihy,thihy
+negrinv,victor negrin
+magocg,Rosa Casillas
+damason,David Mason
+xavier.sanchez,Xavier Sanchez Loro
+rhodebump,Phillip Rhodes
+christoph buescher,Christoph Buescher
+jteb,Jan te Beest
+nkrijnen,Nico Krijnen
+tree,Tom Emerson
+koichisenada,Ilia Sretenskii
+leetcooper,Lee Cooper
+tommd,Thomas DuBuisson
+lvton,Lvton. Smith
+nicot,Nico Tonozzi
+rrxjery,Jerry Richard
+dev_johnpatterson@hotmail.com,John Patterson
+yangsongbai,yangsongbai
+sergiusz.urbaniak,Sergiusz Urbaniak
+ypakhomov,Yury Pakhomov
+NinaG,Nina Gracheva
+fabio.germann,germafab
+martinhuber,Martin Huber
+zhangmingsh,Ming Zhang
+Raji,Rajeswari Natarajan
+melix,Cédric Champeau
+markharwood@totalise.co.uk,Mark Harwood
+yurymalkov,Yury Malkov
+solrtrey,Trey Grainger
+gunasekaran.chakkravarthi@gmail.com,gunasekaran
+pablo.castellanos,Pablo Castellanos
+horkhe,Maxim Vladimirskiy
+jyri,Jyri
+stevemer,Steve Merritt
+tomsaleeba,Tom Saleeba
+hkirk,Henrik Bitsch Kirk
+prosanes,Pedro Rosanes
+jasonstack,Zhao Yang
+maximkr,Maxim Kramarenko
+fredericm,frederic
+elizabethnisha,Elizabeth Nisha
+jwatt,Jonathan Watt
+rangadi,Raghu Angadi
+alex.paransky@individualnetwork.com,Alex Paransky
+carlos_aller@condisline.com,Carlos
+elmer.garduno,Elmer Garduno
+tdutreui,Thomas Dutreuilh
+revusky,Jonathan Revusky
+sgonyea,Scott Gonyea
+oswaldodantas,Oswaldo Dantas
+shurik,Alexander Gutkin
+qiqi,Liwei
+roman.chyla@gmail.com,Roman Chyla
+venkat11,Ram Venkat
+bcurnow,Brian Curnow
+akshayjava,Akshay Java
+federico.grilli@gmail.com,Federico Grilli
+sezelee,milesli
+zhaoyan1117,Yan Zhao
+sulemanmubarik,suleman mubarik
+kdg,Kurt De Grave
+vinod@vinodsingh.com,Vinod Singh
+mrit64,MRIT64
+yasoja,Yasoja Seneviratne
+danson@germane-software.com,Dale Anson
+bpasero,Benjamin Pasero
+olk.ptv,Oliver Kaleske
+pwolanin,Peter Wolanin
+genernic,Lars Olson
+andreluiznsilva,André Luiz Nascimento Silva
+helianbobo,Liu Chao
+eyalp,Eyal Post
+ashley.sole,Ashley Sole
+luetzken@itaw.hu-berlin.de,Stefan Lützkendorf
+pjhimself,Patrick Jungermann
+tom@slaxicon.org,Tom Green
+torbjok,Torbjørn Køhler
+gtroitskiy,Grigoriy Troitskiy
+ocean,ocean
+eribeiro,Edward Ribeiro
+PuneethB,Puneeth Bikkumanla
+srajendra,Sachin Rajendra
+rakris,Radhakrishna Bhat
+sam.davis,Sam Davis
+c.cudennec,Christopher Cudennec
+kamal_ebay,Kamaldeep Singh
+qwong,wang
+tarrall,Robert Tarrall
+fbaligand,Fabien Baligand
+michalfapso,Michal Fapso
+pwilkins,Peter Wilkins
+hcayless,Hugh Cayless
+samuelgmartinez,Samuel García Martínez
+gustavonalle,G Fernandes
+tyh73bac,Tyheem Backer
+eric.vachon@temis-group.com,Eric Vachon
+georgew,george washington
+akurtakov,Alexander Kurtakov
+bik1979,Victor Ruiz
+ghuber,Greg Huber
+sirvan,Sirvan Yahyaei
+tangfl,tangfulin
+mguillemot@yahoo.fr,Marc Guillemot
+misc2006@danielnaber.de,Daniel Naber
+samuelma,samuel ma
+nbommu,Niranjan
+Efalia,Efalia
+tdunning@veoh.com,Ted Dunning
+jeoen,Jeroen Vuurens
+purbecks,Mike Cawson
+marzuc,Chris Marzullo
+gnayak,Girish Nayak
+lmiller@encryptx.com,leslie miller
+yasha,Yakov Sirotkin
+jpa458,Julian Atkinson
+EndymionUSA,Endymion Dylan
+ronanker,Ronan KERDUDOU
+rafal@caltha.pl,Rafal Krzewski
+spencer@jstor.org,Spencer W. Thomas
+klaporte,Ken LaPorte
+drainer,David Rainer
+tmgstev,Tristan Stevens
+gregor.kaczor,Gregor Kaczor
+smckay,Steve McKay
+diogoedl,Diogo Guilherme Leão Edelmuth
+mikedemi,Mykhailo Demianenko
+zjshen,Zhijie Shen
+ndespain,Ndes
+jcarl,Carl Antaki
+lukehan,Luke Han
+boonious,Boon Low
+guitarrosie,Ivan Stojanovic
+atkinschang,Atkins Chang
+rhillegas,Richard N. Hillegas
+rob5624,Rob ten Hove
+David Turner,David Turner
+bbdouglas-basis,Benjamin Douglas
+jmiserez,Jeremie Miserez
+domsew,Dominik
+tomfotherby,Tom Fotherby
+jan.fruehwacht,Jan Fruehwacht
+harishjira,Harish Kayarohanam
+aleree,Alexander Reelsen
+allupaku,Althaf
+supriyanaidupelluru,supriya
+stewi2,Stefan Will
+michael@yellowhouseassociates.com,michael
+mpelzsherman,Michael Pelz-Sherman
+fergalmonaghan,Fergal Monaghan
+mbarry@cos.com,Mike Barry
+jimregan,Jim Regan
+emmanuel.espina,Emmanuel Espina
+markstreitman,Mark Streitman
+rlaboisse@opsys.fr,Romain Laboisse
+dwu@sonypictures.com,Daniel Chien-Hsing Wu
+t.will@linguatec.de,thilo will
+lae,Lae
+aspa,Marko Asplund
+pctony,Tony Stevenson
+yiluncui,Yilun Cui
+pchollet,Pascal Chollet
+hkonno,KONNO, Hiroharu
+solruser,solr-user
+thepanz,Ema Panz
+antoineb,Antoine
+maxbeutel,Max Beutel
+blueye118,Eric
+zhanglei,Lei Zhang
+yhector@salesforce.com,Yannis Hector
+artemv,Artem Vasiliev
+adhit,Reinardus Surya Pradhitya
+smlee0818,soomyung
+soomyung,SooMyung Lee
+daedeqi,Dai Deqi
+udanax,Edward J. Yoon
+bgroose,Brian Groose
+jasonab,Jason Bennett
+mehta_muktesh,Muktesh Mehta
+mcalice,Semion Mc Alice
+coolseraph,Yiqing Jin
+andrei@tandoev.de,Andrei Tandoev
+gchanan,Gregory Chanan
+wuda0112,wuda
+michael.suedkamp@docware.de,michael.suedkamp
+Save,Simon poortman
+ferwasy,Fernando Wasylyszyn
+jefft,Jeff Turner
+apatry,Alexandre Patry
+thomas_connolly,Thomas Connolly
+nbelisle,Nicolas Belisle
+cdevarenne@yahoo.com,Claude Devarenne
+mahesh_reddy77@yahoo.com,Maheshwara Reddy
+alex@apache.org,Alex Chaffee
+mgarski,Michael Garski
+martinc,Martin Cooper
+almaw,Alastair Maw
+agallou,Adrien Gallou
+ethant,Ethan Tao
+cdanningerCV,Christian Danninger
+nirmal.c@gmail.com,Nirmal Chidambaram 
+jbigdata.fr,www.jbigdata.fr
+rsharma48477,Raj Sharma
+fridrik,Federico Fissore
+noname90,NHV
+akanksha88,Akanksha Jain
+kiju98,Kiju Kim
+smikulchik,Stanislav Mikulchik
+sanjoy,Sanjoy Ghosh
+tyr,Peter
+tdsrinivas,Srinivas Raj
+amit_ak,Amit Kulkarni
+rynekmedyczny.pl,RynekMedyczny.pl
+jnatour,Jamal Natour
+buddikagaj,Buddika Gajapala
+gutte,Thomas Guttesen
+mohit.godwani,Mohit Godwani
+ezust,alan ezust
+Martin Hermann,Martin Hermann
+matt@sidefx.com,Matt Chaput
+cloudwave,Jinsong Hu
+rballing@gmx.at,t87m87p90
+mellowonpsx,Sergio Leoni
+joan.roch@videotron.ca,Joan Roch
+coderplay,Min Zhou
+18519283579,Guoqiang Jiang
+angadp,Angadpreet Nagpal
+gyzsolt,Zsolt Gyulavari
+neoremind,neoremind
+arames,Simon Arame
+wkchan,Kai Chan
+woelfle,Woelfle
+crystal,xlzhang
+arofer,Allan Rofer
+brian.kmetz@hsn.net,Brian Kmetz
+calderon.joe,Joe Calderon
+javamonkey79,Shaun A Elliott
+bjornhjelle,Bjørn Hjelle
+rbpandey,r6p
+idoub,Isaac Doub
+howlingdawg,Dave Been
+narmok,Basem Narmok
+zampetti,Marc Zampetti
+a.popitich,Aleksandr Popitich
+deyinchen,deyinchen
+wjw465150,wjw465150
+fckdp@ok.ru,Pasha Bizhan
+miguelferreira,Miguel Ferreira
+rishabhmaurya,Rishabh Maurya
+rajesh29546,Rajesh T
+tavi,Tavi Nathanson
+maurizio316,Maurizio
+dessaigne,Nicolas Dessaigne
+shia,Zhang Yuan
+rwoolf,Ross Woolf
+vojtechtoman,Vojtěch Toman
+mghotra81,Manpreet
+jibo_john,Jibo John
+a.sterbini,Andrea Sterbini
+jrennie,Jason Rennie
+ilyak,Ilya Kasnacheev
+Lakedaemon,Olivier Binda
+moberhuber,Martin Oberhuber
+make,Matthias Kerkhoff
+fuu,Juha Haaga
+egarcia_atlassian,Edu Garcia
+hagis,Tero Hagström
+andywebb1975,Andy Webb
+epotiom,Egor Potemkin
+sdiz,Daniel Cheng
+ayushman17,AYUSHMAN SINGH CHAUHAN
+birukou,Aliaksandr Birukou
+david.gianetti@kofc.org,David.Gianetti@Kofc.Org
+wallen@cyveillance.com,Will Allen
+humbedooh,Daniel Gruno
+chillon_m,chillon.m
+petrovich,Serge Negodyuck
+gilko,George Campbell
+samiuddinarif,sameeuddin Mohammed
+mkrogemann,Markus Krogemann
+jrx,Jan Rieger
+jwbroek,Jan-Willem van den Broek
+jdruse,Jon Druse
+jcalabrese,Jason Calabrese
+Vincent Fang,Tianyu Fang
+birsan@ca.ibm.com,Dorian Birsan
+ashah301182,nkeet
+ebatzdor,Eric B
+steve_chen_veeva,Steve Chen
+nkeet,nkeet shah
+Daredevil780,Dishant Sharma
+charles_s_patridge,Charles S Patridge
+contact@wennysoft.de,Michael Wenig
+chedong@yahoo.com,Che Dong
+raymond@ibase.com.hk,Raymond
+rd,diasp
+tolot27,Mathias Walter
+angsaa,Sally Ang
+jdm,Jay Mundrawala
+smolloy,Steve Molloy
+bhengra.amit@gmail.com,amit bhengra
+raminmjj,Ramin Alirezaee
+anne@veling.nl,Anne Veling
+martinblech,Martin Blech
+erik.van.zijst,Erik van Zijst
+helenwarren,Helen Warren
+muraalee,Murali Varadarajan
+dnavas,David C. Navas
+Pettit,Shane
+AdamDWilliams,Adam Williams
+GennadiyGeyfman,Gennadiy Geyfman
+karls,Karl Sanders
+cfuller@atlassian.com,Chris Fuller
+rboulton,Richard Boulton
+zapper,Anthony Mckale
+bomix,Håkon T. Bommen
+aheaven,Alexander S.
+des.lownds,Des Lownds
+IanNLA,Ian
+ruchirc,ruchir choudhry
+ramayer,Ron Mayer
+dgoldhan,Dirk Goldhan
+deshpandeashu,Ashutosh Deshpande
+FFFro,jiarun.yang
+shamikchand002@gmail.com,Shamik
+chisty.sust,Ahmed Chisty
+colton,Colton Jamieson
+manish82,Manish
+Krishna Keldec,Krishna Keldec
+bjsion,Ben Sion
+SchachMatt,Martin Demberger
+jrobicha,Jean-Philippe Robichaud
+kazuhira,Ippei Matsushima
+plaflamme,Philippe Laflamme
+luceneuser,Roshini
+ksenechal,Kevin Senechal
+wangzj,wangzj
+michaelkrkoska,Michael Krkoska
+tomi,Tomislav Gountchev
+gaetan79,Gaetan
+leoshabr,Sabbir Kumar Manandhar
+ksprochi,Keith Sprochi
+kirilzack@yahoo.com,Kiril Zack
+bgfeldm,Brian Feldman
+thebigjc,Jordan Christensen
+asel@datafull.com,Ariel
+csaba.ludescher@idtim.ro,Csaba Ludescher
+speedplane,Michael Sander
+smacke,Stephen Macke
+jeffhuang,Jeff Huang
+cooneyg,Geoff Cooney
+unnutz,Artyom Sokolov
+mashudong,mashudong
+amin,Amin Mohammed-Coleman
+heng.mei@gmail.com,Heng Mei
+syyang,Seung-Yeoul Yang
+poluripradeep2009,Pradeep K Poluri
+abeliakov,Andrei Beliakov
+dserodio,Daniel Serodio
+Alchemist0823,Forrest Sun
+szantaikis,Peter Szantai-Kis
+arvindkr,Arvind Kumar Sahu
+tanadeau,Trent Nadeau
+Sailendra,SAILENDRA PAVAN
+alfarris@prodigy.net,Drew Farris
+eroux,Elie Roux
+Jakozaur,Jacek Migdal
+alan.boo,Alan Boo
+olvesh,Olve Sæther Hansen
+mrbsd,Bert Sanders
+grcevski,Nikola Grcevski
+risbood,Pankaj Risbood
+coliny,Colin Yu
+jianwu_chen,jianwu chen
+mattj,Matt Jones
+maxlynch,Max Lynch
+abdollar,Abdul Chaudhry
+jj380382856,jin jing
+vassil.zorev87,Vassil Zorev
+bsp,Sergey Vladimirov
+tobr,Tobias Rübner
+blizzy-keyword-apache_bugs.e23ed5@blizzy.de,Maik Schreiber
+chenlongHuo,chenlong huo
+jk@jkraemer.net,Jens Kraemer
+qmx,Douglas Campos
+raikoe,Raiko Eckstein
+lsharma3,Lucky Sharma
+elflaco,Antonio Bruno
+quachtaibuu,Quách Tài Bửu
+vkornev,Vladimir Kornev
+sarxos,Bartosz Firyn
+eric.daws@uk.consulting.fujitsu.com,Eric J Daws
+larsko,Lars Kotthoff
+1ceb00da,Aditya Dhulipala
+kdana,Kevin Dana
+cpp@vip.163.com,Charles Liu
+luispenya@aqs.es,Luis Peña
+ryanobjc,ryan rawson
+xan_ps,Prateek Sachan
+jeffreym,Jeffrey Morlan
+krokicki,Konrad Rokicki
+charles_crouch@hotmail.com,Charles Crouch
+tejasbhanushali,Tejasbhanushali
+ralekseenkov,Roman Alekseenkov
+pdlug,Paul Dlug
+aparo,Alberto Paro
+m.j.bomhoff@student.utwente.nl,Matthijs Bomhoff
+jorgen@polopoly.com,Jorgen Rydenius
+tobias.graf,Tobias Graf
+estoyausente,Samuel Solís
+paultaylor,Paul Taylor
+michcio,Michał Dybizbański
+g-tibana@uniandes.edu.co,Gerardo Tibaná
+nkvoll,Njal Karevoll
+kelvint@apache.org,Kelvin Tan
+agrebnev,Andrey Grebnev
+rstaveley,Rob Staveley (Tom)
+daveyost,Dave Yost
+terry@net-frame.com,Terry Steichen
+agallardo@agsoftware.dnsalias.com,Antonio Gallardo
+mark_spoon,Christian
+millerjeff0,Jeff Miller
+esther.quansah,Esther Quansah
+Eva Popenda,Eva Popenda
+vyuryev@rambler.ru,Vladimir Yuryev
+jason.polites@gmail.com,jason.polites
+alt@picnic.demon.co.uk,Andy Thomas
+sanne.grinovero,Sanne Grinovero
+tom_lt,tom liu
+williamarcondes,William
+bharaths,bharath.s
+mch2,Marc Handalian
+erik@seecr.nl,Erik Groeneveld
+yunfeng,wu,yunfeng
+dimamay,Dima May
+superjo,Johannes Christen
+christoph.schmidt@moresophy.com,Christoph Schmidt
+yonadav,YL
+oridool,Ori D
+myhexin,HeXin
+jbarth_ubhd,Jochen Barth
+nabucko,Markus
+waldoppper,Walt Elder
+kyllerss,Kyle L.
+marxin,Martin Liška
+cbammann,Christoph Bammann
+mikestreeton,michael streeton
+sebasmtech@gmail.com,Sebastin Naveen
+aschurman,Andrew Schurman
+Munkyu,Munkyu Im
+durgadeep,DURGA DEEP
+jpiekos@easyask.com,jpiekos
+tsgrieco@yahoo.com,Tony Smith-Grieco
+dnimkar,Dilip Nimkar
+srimilind,Milind Srivastava
+vincentarnaud90,Vincent Arnaud
+wangjpzju,wang jianping
+nmehta79,Nishant Mehta
+danish_c,Danish Contractor
+frankmanzhu,Frank Zhu
+jmark,John Mark
+boxtelp,Pieter
+nicko,Nicko Cadell
+mirko.ebert@gmx.net,Mirko Ebert
+philipp_meister@hotmail.com,Philipp Meister
+QuasiChameleon,Kevin Crosby
+kenneth_aitken@freenet.de,Kenneth Aitken
+Anonymous,Anonymous
+past@ebs.gr,Panagiotis Astithas
+baltendo,Bernhard Altendorfer
+mochoa,Marcelo F. Ochoa
+pichaio@yahoo.com,Pichai Ongvasith
+fabrice.claes@inno.com,fabrice claes
+yajunliu,Let me out
+brucekarsh,Bruce Karsh
+andrewschoen,Andrew Schoen
+boice,Lucifer Boice
+Nirf8,Nir Finkelstein
+ephemeris.lappis@tiscali.fr,Ephemeris Lappis
+danz,Danz He
+jblangston@datastax.com,J.B. Langston
+anthonyrasmussen,Anthony Rasmussen
+Vishmi Money,Vishmi Money
+dragan.ivanovic,Dragan Ivanovic
+yuvalf,Yuval Feinstein
+joaquin,Joaquin Perez-Iglesias
+vinaysetty,Vinay Setty
+iantowey,ian towey
+katja,Katja Hofmann
+skeptikos,J.J. Larrea
+wwm1994,Weiming Wu
+bnicolotti@siapcn.it,Bartolomeo Nicolotti
+Park JungHo,Park JungHo
+rjohnson,Rich Johnson
+jesperbadstue,Jesper Badstue
+rjgodoy,Javier Godoy
+aishwaryad,Aishwarya Dabhade
+rosher,Dan Rosher
+gaurav_bm82,Gaurav Gupta
+piotr.pezik,Piotr Pęzik
+rminelli,Roberto Minelli
+desruisseaux,Martin Desruisseaux
+tsandor,Tamas Sandor
+tommy.cheung@arontac.com,Tommy Cheung
+fdiebold,Florian Diebold
+benoitf,Florent BENOIT
+csteinert,Christian Steinert
+daniel.aschauer,Daniel Aschauer
+mAleythe,Michael Aleythe
+chow,Alex Chow
+vrparekh@gmail.com,vishal parekh
+jrogers,Jeff Rogers
+matt@atlassian.com,Matt Ryall
+stig.lau,Stig Lau
+zhamdi,Zied Hamdi
+becky825,zyfan
+c2h5oh,Maciej Lisiewski
+maho,Maho NAKATA
+toverbal,Jay Es
+adeelmahmood,Adeel Qureshi
+m9aertner,Matthias Gärtner
+gnewton,Glen Newton
+shalsey,steve halsey
+work.asr,Adam Ringel
+jeromelanneluc,Jerome Lanneluc
+Ashamandi,Ayah Shamandi
+neverlan,simon raphael
+vivek89,vivek
+alexey_kozhemiakin,Alexey Kozhemiakin
+em,Em
+pgorla,Patricia Gorla
+sbower,Steven Bower
+maggon,Sameer Maggon
+sharmaremuk,Ramesh Kumar Thirumalaisamy
+vempap,Phani Vempaty
+beaker,Alex Watson
+joern,Jörn Kottmann
+nederhrj,Rene Nederhand
+rashi,rashi gandhi
+zzullick,Zack Zullick
+andrew janowczyk,Andrew Janowczyk
+redguy666,Maciej Lizewski
+kguelzau,Kai Gülzau
+yuval_v@yahoo.com,yuvalv
+amiton23@hotmail.com,amit
+soyouz,olivier soyez
+Surendhar,Surendhar
+apache.org@alias.byzantine.no,Alexander Staubo
+antonha,Anton Hägerstrand
+rhett@detailedbalance.net,Rhett Sutphin
+davwendt,David Wendt
+ChasenY,chaseny
+alexeya,Alex Alishevskikh
+jimjonah@electricstudio.com,Jim Jonah
+karin,karin
+treffer,René Treffer
+aw,Allen Wittenauer
+dallan40,Dallan Quass
+dwebb,David Webb
+kenkyee@excite.com,Ken Yee
+kwatters,Kevin Watters
+mavimaster,Fatih Uzdilli
+fjalvarezs,Francisco Alvarez
+shahzad992,shahzad ahsan 
+samfukuda,Susumu Fukuda
+tamer.saleh,Tamer Saleh
+scottsom,Scott Somerville
+kraftb,Bernhard Kraft
+byron@mozdex.com,Byron Miller
+wireframe,Ryan Sonnek
+ickzon,Holger Rehn
+matomira,Fernando Mato Mira
+fterrier,François Terrier
+punk,zhangzhenan
+jgorski,Jonas Gorski
+amp834,Masoud
+wchao@yahoo.com,wchao
+slavelle,Sean Lavelle
+dionoid,Dion Olsthoorn
+rustamabd,Rustam Abdullaev
+shenzhuxi,shenzhuxi
+parshadi@endeavors.com,Pasha Arshadi
+chenzx,Chen Zhixiang
+vinod1812,vinod kumar
+suni_cb,Sunitha Belavagi
+esanjuanelo@x-cago.com,Enrique Sanjuanelo
+sky2016,tom
+kelvint,Kelvin Tan
+xiaoshuai,帅广应
+mplatvoet,Mark Platvoet
+olimcc,oli mcc
+davehatesbugs,David Fertig
+zyoav,yoav zibin
+florian.sauvin@epfl.ch,Florian Sauvin
+ddaniliuc,Dumitru Daniliuc
+ipooley,Ian Pooley
+cmad@lanlab.de,Clemens
+lightguard,Jason Porter
+lucene-list-dev@webdoyen.com,Jeff Patterson
+weiqiyiji,Luo Ji
+luciano73,luciano aparecido dos santos
+feistner,Lars Feistner
+huawei_xu,huawei_xu
+youyi377,richie
+johnnyj,Johnny Jenkins
+michael@wyraz.de,Michael Wyraz
+jan.eerdekens,Jan Eerdekens
+ypeilin,Peilin Yang
+vaidy,vaidy
+ilan,Ilan Ginzburg
+idelvall,Ignacio del Valle Alles
+jonenst2,Jon Harper
+gschneck,Geoffroy Schneck
+dylan_sd,Dylan SD
+dmabe@constellagroup.com,David Mabe
+adam@labkey.com,Adam Rauch
+jmethot@bea.com,John Methot
+troilusc,Xi Caoqiu
+wenyao,wenyao
+ackel,Ackel Filia
+bhenriet,Benjamin Henriet
+abrun@opsys.fr,Antoine Brun
+KingofLucene,Jintao Jiang
+TimOwen,Tim Owen
+adeppa,adeppa
+longlei,longlei
+napoli.marcio,Marcio Napoli
+patrick.hochstenbach@ugent.be,Patrick Hochstenbach
+gerritjvv,Gerrit Jansen van Vuuren
+mmurphy@codecorps.org,Mark Murphy
+zhuravskiy.vs,Zhuravskiy Vitaliy
+gilinachum,Gili Nachum
+cabeer,Chris Beer
+jasontedor,Jason E Tedor
+gilles.delaby,Gilles Delaby
+fiska,Fis Ka
+cameronl,Cameron
+chaimpeck,Chaim Peck
+pmarty,Patrick Marty
+emecas,Emerson Castaneda
+anath,Anat
+shanedetsch,Shane Detsch
+bitkid,Sascha Sadat-Guscheh
+aw90006,Amit Wamburkar
+mikeree,Mike Ree
+fgc,Franco Callari
+ljcollins25,Lance Collins
+akshya_kumar,Akshya kumar

--- a/migration/src/common.py
+++ b/migration/src/common.py
@@ -23,6 +23,7 @@ GITHUB_LUCENE_COMMIT_AUTHORS = "github-lucene-commit-authors.csv"
 
 ISSUE_MAPPING_FILENAME = "issue-map.csv"
 ACCOUNT_MAPPING_FILENAME = "account-map.csv"
+JIRA_USERS_FILENAME = "jira-users.csv"
 
 ASF_JIRA_BASE_URL = "https://issues.apache.org/jira/browse"
 
@@ -146,6 +147,18 @@ def read_account_map(account_mapping_file: Path) -> dict[str, str]:
                 continue
             id_map[cols[0]] = cols[1]  # jira name -> github account
     return id_map
+
+
+def read_jira_users_map(jira_users_file: Path) -> dict[str, str]:
+    users_map = {}
+    with open(jira_users_file) as fp:
+        fp.readline()  # skip header
+        for line in fp:
+            cols = line.strip().split(",")
+            if len(cols) < 2:
+                continue
+            users_map[cols[0]] = cols[1]  # jira name -> jira display name
+    return users_map
 
 
 def retry_upto(max_retry: int, interval: float, logger: logging.Logger):


### PR DESCRIPTION
Close #63.

- Capture `[~username]` mentions as well as `@username` mentions.
- Show full name if a github account is not available for the Jira username.

e.g.,

![Screenshot from 2022-07-23 16-32-50](https://user-images.githubusercontent.com/1825333/180595438-a114aad2-3c8a-4171-9c0a-183bf1235c6f.png)

is converted to

![Screenshot from 2022-07-23 16-32-09](https://user-images.githubusercontent.com/1825333/180595397-ed666e95-424a-4a85-8d45-c8245ce88900.png)
