### PR TITLE
Preserve Jira 'Labels'

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -54,7 +54,8 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
         attachments = extract_attachments(o)
         linked_issues = extract_issue_links(o)
         subtasks = extract_subtasks(o)
-        pull_requests =extract_pull_requests(o)
+        pull_requests = extract_pull_requests(o)
+        jira_labels = extract_labels(o)
 
         reporter_gh = account_map.get(reporter_name)
         reporter = f"{reporter_dispname} (@{reporter_gh})" if reporter_gh else f"{reporter_dispname}"
@@ -185,6 +186,8 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
                     labels.append(l)
             else:
                 logger.error(f"Unknown Component: {c}")
+        for label in jira_labels:
+            labels.append(f"legacy-jira-label:{label}")
 
         data = {
             "issue": {

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -79,6 +79,10 @@ def extract_components(o: dict) -> list[str]:
     return [x.get("name", "") for x in o.get("fields").get("components", [])]
 
 
+def extract_labels(o: dict) -> list[str]:
+    return o.get("fields").get("labels", [])
+
+
 def extract_attachments(o: dict) -> list[tuple[str, int]]:
     attachments = o.get("fields").get("attachment")
     if not attachments:


### PR DESCRIPTION
#61 

Port `Labels` as `legacy-jira-label:xxx`.

e.g. `newdev` is preserved as `legacy-jira-label:newdev`
![Screenshot from 2022-07-23 20-07-11](https://user-images.githubusercontent.com/1825333/180602504-61c0c3a4-45fc-466f-b00a-89fdb33e22e0.png)
