### PR TITLE
Port 'Environment' custom field

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -43,6 +43,7 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
         description = extract_description(o).strip()
         status = extract_status(o)
         issue_type = extract_issue_type(o)
+        environment = extract_environment(o)
         (reporter_name, reporter_dispname) = extract_reporter(o)
         (assignee_name, assignee_dispname) = extract_assignee(o)
         created = extract_created(o)
@@ -104,6 +105,9 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
             body += f", resolved {resolutiondate_datetime.strftime('%b %d %Y')}"
         elif created_datetime.date() != updated_datetime.date():
             body += f", updated {updated_datetime.strftime('%b %d %Y')}"
+
+        if environment:
+            body += f'\nEnvironment:\n```\n{environment}\n```\n'
 
         if len(attachment_list_items) > 0:
             body += f'\nAttachments: {", ".join(attachment_list_items)}'

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -41,6 +41,11 @@ def extract_issue_type(o: dict) -> str:
     return issuetype.get("name", "") if issuetype else ""
 
 
+def extract_environment(o: dict) -> str:
+    environment = o.get("fields").get("environment", "")
+    return environment if environment else ""
+
+
 def extract_reporter(o: dict) -> tuple[str, str]:
     reporter = o.get("fields").get("reporter")
     name = reporter.get("name", "") if reporter else ""


### PR DESCRIPTION
Noticed there is an optional or custom metadata field "Environment" in Jira. This is not shown in the default view, but reporters can add arbitrary texts (which can be very long) in the field if they have detailed environment information. For example https://issues.apache.org/jira/browse/LUCENE-8532

For readability/visibility, I'd use a code block.
![Screenshot from 2022-07-23 22-10-50](https://user-images.githubusercontent.com/1825333/180606477-601df490-8a15-47c4-a197-0a87221b0189.png)
