### PR TITLE
Port 'Resolution' as a label

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -57,6 +57,7 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
         subtasks = extract_subtasks(o)
         pull_requests = extract_pull_requests(o)
         jira_labels = extract_labels(o)
+        resolution = extract_resolution(o)
 
         reporter_gh = account_map.get(reporter_name)
         reporter = f"{reporter_dispname} (@{reporter_gh})" if reporter_gh else f"{reporter_dispname}"
@@ -192,6 +193,8 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
                 logger.error(f"Unknown Component: {c}")
         for label in jira_labels:
             labels.append(f"legacy-jira-label:{label}")
+        if resolution:
+            labels.append(f"legacy-jira-resolution:{resolution}")
 
         data = {
             "issue": {

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -46,6 +46,13 @@ def extract_environment(o: dict) -> str:
     return environment if environment else ""
 
 
+def extract_resolution(o: dict) -> Optional[str]:
+    resolution = o.get("fields").get("resolution")
+    if resolution:
+        return resolution.get("name")
+    return None
+
+
 def extract_reporter(o: dict) -> tuple[str, str]:
     reporter = o.get("fields").get("reporter")
     name = reporter.get("name", "") if reporter else ""


### PR DESCRIPTION
Close #72 

Resolved issue:

![Screenshot from 2022-07-24 19-42-11](https://user-images.githubusercontent.com/1825333/180643472-4b4f8c92-1ed3-406f-a25e-5a391a89c236.png)

For unresolved issues, there is no "Resolution" for them, so no additional label is attached.
