### PR TITLE
Avoid duplicate labels

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -208,6 +208,9 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
             labels.append(f"legacy-jira-resolution:{resolution}")
         if priority:
             labels.append(f"legacy-jira-priority:{priority}")
+        
+        # ensure there are not duplicate labels
+        labels = list(set(labels))
 
         data = {
             "issue": {


### PR DESCRIPTION
If there are duplicate labels, the GitHub import request fails.

This is the (not very informative) error message.
```
[2022-07-26 04:15:07,711] ERROR:import_github_issues: Import GitHub issue /mnt/hdd/repo/lucene-jira-archive/migration/github-import-data/GH-LUCENE-2639.json was failed. status=failed, errors=[{'location': '/issue', 'resource': 'Issue', 'field': None, 'value': None, 'code': 'error'}]
```