### PR TITLE
tweak legacy-jira-label texts

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -203,6 +203,33 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
             else:
                 logger.error(f"Unknown Component: {c}")
         for label in jira_labels:
+            # GitHub does not allow commas in labels
+            label = label.replace(",","")
+            # several label texts have to be tweaked; otherwise import fails. don't know why.
+            # split tokens with '-'
+            if label == "queryparser":
+                label = "query-parser"
+            if label == "fastvectorhighlighter":
+                label = "fast-vector-highlighter"
+            # capitalize
+            if label == "highlighter":
+                label = "Highlighter"
+            if label.startswith("java"):
+                label = re.sub(r"^java", "Java", label)
+            # uncapitalize
+            if label == "Documentation":
+                label = "documentation"
+            if label == "Sort":
+                label = "sort"
+            if label == "Highlighting":
+                label = "highlighting"
+            if label == "Stemmer":
+                label = "stemmer"
+            if label == "Scorer":
+                label = "scorer"
+            # truncate
+            if label == "spatialrecursiveprefixtreefieldtype":
+                label = "spatialrecursiveprefixtree"
             labels.append(f"legacy-jira-label:{label}")
         if resolution:
             labels.append(f"legacy-jira-resolution:{resolution}")


### PR DESCRIPTION
I really don't have an idea about the cause but GitHub won't accept some label texts via import API.

e.g.
```
[2022-07-26 10:06:40,904] ERROR:import_github_issues: Import GitHub issue /mnt/hdd/repo/lucene-jira-archive/migration/github-import-data/GH-LUCENE-5381.json was failed. status=failed, errors=[{'location': '/issue/labels[6]', 'resource': 'Label', 'field': 'name', 'value': 'legacy-jira-label:highlighter', 'code': 'invalid'}]
[2022-07-26 11:11:32,526] ERROR:import_github_issues: Import GitHub issue /mnt/hdd/repo/lucene-jira-archive/migration/github-import-data/GH-LUCENE-5886.json was failed. status=failed, errors=[{'location': '/issue/labels[2]', 'resource': 'Label', 'field': 'name', 'value': 'legacy-jira-label:java8', 'code': 'invalid'}]
[2022-07-26 11:34:15,469] ERROR:import_github_issues: Import GitHub issue /mnt/hdd/repo/lucene-jira-archive/migration/github-import-data/GH-LUCENE-6057.json was failed. status=failed, errors=[{'location': '/issue/labels[8]', 'resource': 'Label', 'field': 'name', 'value': 'legacy-jira-label:Documentation', 'code': 'invalid'}, {'location': '/issue/labels[10]', 'resource': 'Label', 'field': 'name', 'value': 'legacy-jira-label:Sort', 'code': 'invalid'}]
```