### PR TITLE
Move Jira information to comment header

### DIFF
--- a/migration/src/jira2github_import.py
+++ b/migration/src/jira2github_import.py
@@ -175,9 +175,9 @@ def convert_issue(num: int, dump_dir: Path, output_dir: Path, account_map: dict[
 
             jira_comment_link = f'https://issues.apache.org/jira/browse/{jira_id}?focusedCommentId={comment_id}&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-{comment_id}'
                 
-            comment_body += f'[Legacy Jira: {comment_author(comment_author_name, comment_author_dispname)} on [{comment_time}]({jira_comment_link})]\n'
+            comment_data = f'[Legacy Jira: by {comment_author(comment_author_name, comment_author_dispname)} on [{comment_time}]({jira_comment_link})]\n\n{comment_body}'
             data = {
-                "body": comment_body
+                "body": comment_data
             }
             if comment_created:
                 data["created_at"] = jira_timestamp_to_github_timestamp(comment_created)


### PR DESCRIPTION
Suggested in https://github.com/apache/lucene-jira-archive/issues/1#issuecomment-1200115706.

> Maybe it'd be better to move the original comment author up to the top of the converted comment? Otherwise, for long comments, it's hard to see who's replying.

![Screenshot from 2022-07-30 20-18-21](https://user-images.githubusercontent.com/1825333/181908510-56b6a011-98b6-4ccd-b146-a477e9953ec7.png)

will be

![Screenshot from 2022-07-30 20-18-46](https://user-images.githubusercontent.com/1825333/181908528-382916ec-07c5-4db1-b7a4-d4151e7962c2.png)
