### PR TITLE
Escape github style issue links

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -231,6 +231,7 @@ REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
 REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.]+)|((?<=[\s\(\"'])@[\w\.]+)(?=[\s\)\"'\?!,\.$])")  # this regex may capture only "@" + "<username>" mentions
 REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.]+\])|((?<=[\s\(\"'])\[~[\w\.]+\])(?=[\s\)\"'\?!,\.$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
+REGEX_GITHUB_ISSUE_LINK = re.compile(r"(\s)(#\d+)(\s)")
 
 
 def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: dict[str, str] = {}, jira_users: dict[str, str] = {}) -> str:
@@ -241,6 +242,11 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
         for src, repl in att_replace_map.items():
             if m.group(2) == src:
                 res = f"[{m.group(1)}]({repl})"
+        return res
+
+    def escape_gh_issue_link(m: re.Match):
+        # escape #NN by backticks to prevent creating an unintentional issue link
+        res = f"{m.group(1)}`{m.group(2)}`{m.group(3)}"
         return res
 
     text = re.sub(REGEX_CRLF, "\n", text)  # jira2markup does not support carriage return (?)
@@ -284,7 +290,11 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
             mention = lambda: f"@{gh_m}" if gh_m else disp_name if disp_name else f"`~{jira_id}`"
             text = text.replace(m, mention())
     
+    # convert links to attachments
     text = re.sub(REGEX_LINK, repl_att, text)
+
+    # escape github style cross-issue link (#NN)
+    text = re.sub(REGEX_GITHUB_ISSUE_LINK, escape_gh_issue_link, text)
 
     return text
 


### PR DESCRIPTION
#94 

I don't think we can apply sophisticated phrase extraction though, it would be easy to insert backticks right before and after `#NN` to prevent unintentional issue links.

I mean, ideally it'd be great if we could markup `UAX #29`, but here, only the token `#29` is escaped.

![Screenshot from 2022-07-31 12-15-11](https://user-images.githubusercontent.com/1825333/182008290-d6f60d1f-f86e-478d-b4b1-b893702db645.png)


