### PR TITLE
Capture email-address like jira mentions

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -228,8 +228,8 @@ JIRA_EMOJI_TO_UNICODE = {
 
 REGEX_CRLF = re.compile(r"\r\n")
 REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
-REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.]+)|((?<=[\s\(\"'])@[\w\.]+)(?=[\s\)\"'\?!,\.$])")  # this regex may capture only "@" + "<username>" mentions
-REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.]+\])|((?<=[\s\(\"'])\[~[\w\.]+\])(?=[\s\)\"'\?!,\.$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
+REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.@_-]+)|((?<=[\s\(\"'])@[\w\.@_]+)(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "@" + "<username>" mentions
+REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.@_-]+\])|((?<=[\s\(\"'])\[~[\w\.@_]+\])(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
 
 

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -228,8 +228,8 @@ JIRA_EMOJI_TO_UNICODE = {
 
 REGEX_CRLF = re.compile(r"\r\n")
 REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
-REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.@_-]+)|((?<=[\s\(\"'])@[\w\.@_]+)(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "@" + "<username>" mentions
-REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.@_-]+\])|((?<=[\s\(\"'])\[~[\w\.@_]+\])(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
+REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.@_-]+)|((?<=[\s\(\"'])@[\w\.@_-]+)(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "@" + "<username>" mentions
+REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.@_-]+\])|((?<=[\s\(\"'])\[~[\w\.@_-]+\])(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
 
 


### PR DESCRIPTION
Jira username can be a mail address. The converter script capture them correctly.

![Screenshot from 2022-07-31 13-59-44](https://user-images.githubusercontent.com/1825333/182010889-63f77e45-a278-437b-b66f-f0750fbb8a81.png)

should be

![Screenshot from 2022-07-31 14-00-08](https://user-images.githubusercontent.com/1825333/182010900-cbfb4b2a-c90b-4edc-b386-5c35b886e995.png)
