### PR TITLE
Escape HTML tag chars in inline quotes

### DIFF
--- a/migration/src/markup/text_effects.py
+++ b/migration/src/markup/text_effects.py
@@ -38,11 +38,18 @@ class TweakedBlockQuote(AbstractMarkup):
 class TweakedQuote(AbstractMarkup):
     is_inline_element = False
 
+    def action(self, tokens: ParseResults) -> str:
+        # escape HTML tag
+        token = tokens[0].replace("<", "&lt;")
+        token = token.replace(">", "&gt;")
+        return token
+
     @property
     def expr(self) -> ParserElement:
         return ("\n" | StringStart()) + Combine(
             Literal("bq. ").setParseAction(replaceWith("> "))
-            + SkipTo(LineEnd()) + LineEnd().setParseAction(replaceWith("\n\n")) # needs additional line feed at the end of quotation to preserve indentation
+            + SkipTo(LineEnd()).setParseAction(self.action)
+            + LineEnd().setParseAction(replaceWith("\n\n")) # needs additional line feed at the end of quotation to preserve indentation
         )
 
 


### PR DESCRIPTION
Similar to #23, `<` and `>` in inline quote `bq.` should be escaped.

e.g.,
in original Jira:
![Screenshot from 2022-07-31 15-12-40](https://user-images.githubusercontent.com/1825333/182012779-4ea216ed-2f09-4ab7-83eb-77c53d73557a.png)

in GitHub:
![Screenshot from 2022-07-31 15-14-01](https://user-images.githubusercontent.com/1825333/182012827-2e6b891f-8389-4474-92bf-4a80306506cf.png)

should be
![Screenshot from 2022-07-31 15-14-27](https://user-images.githubusercontent.com/1825333/182012845-9649227d-9af1-485e-96a0-6a91d4f9058f.png)
