### PR TITLE
Escape tilde to avoid wrong strike-throughs in markdown

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -287,7 +287,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
             disp_name = jira_users.get(jira_id)
             gh_m = account_map.get(jira_id)
             # replace Jira name with GitHub account or Jira display name if it is available, othewise show Jira name with ``
-            mention = lambda: f"@{gh_m}" if gh_m else disp_name if disp_name else f"`~{jira_id}`"
+            mention = lambda: f"@{gh_m}" if gh_m else disp_name if disp_name else f"`@{jira_id}`"
             text = text.replace(m, mention())
     
     # convert links to attachments
@@ -295,6 +295,9 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
 
     # escape github style cross-issue link (#NN)
     text = re.sub(REGEX_GITHUB_ISSUE_LINK, escape_gh_issue_link, text)
+
+    # escape tilde (https://github.com/apache/lucene-jira-archive/issues/89)
+    text = text.replace("~", "\~")
 
     return text
 

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -297,6 +297,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
     text = re.sub(REGEX_GITHUB_ISSUE_LINK, escape_gh_issue_link, text)
 
     # escape tilde (https://github.com/apache/lucene-jira-archive/issues/89)
+    # note: this should be done at the end of text conversoin
     text = text.replace("~", "\~")
 
     return text


### PR DESCRIPTION
#89 

This just escapes all `~` in the text at the last step of the markup conversion to avoid unintentional strike-throughs in Markdown.
Old-style Jira mentions (`~username`) also should be changed to `@username` not to be affected by this patch.

LUCENE-7260 is now correctly rendered without wrong strike-throughs.
https://github.com/mocobeta/migration-test-3/issues/517

![Screenshot from 2022-08-02 22-54-13](https://user-images.githubusercontent.com/1825333/182392060-d6faa48a-d57c-4a23-bdfa-e46ab7289114.png)
