### PR TITLE
Capture cross-issue link that appear at the beginning or a line

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -335,6 +335,7 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, int], gh_number_self:
         return res
 
     text = re.sub(r"(\s)(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
+    text = re.sub(r"(^)(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
     text = re.sub(r"(\()(LUCENE-\d+)(\))", repl_paren, text)
     text = re.sub(r"(\[)(LUCENE-\d+)(\])(?!\()", repl_bracket, text)
     text = re.sub(r"\[(LUCENE-\d+)\]\(https?[^\)]+LUCENE-\d+\)", repl_md_link, text)


### PR DESCRIPTION
![Screenshot from 2022-08-06 17-07-17](https://user-images.githubusercontent.com/1825333/183240503-71776605-4b64-4929-986a-9f9292ee37f0.png)

In this description, "LUCENE-10654" should be remapped to github issue number `#NN` like this.

![Screenshot from 2022-08-06 17-08-33](https://user-images.githubusercontent.com/1825333/183240552-bd0c7f75-c05b-447e-9a25-eadf39156359.png)

Closes #109.