### PR TITLE
Refine regex to capture mentions before/after zenkaku punctuations

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -228,8 +228,8 @@ JIRA_EMOJI_TO_UNICODE = {
 
 REGEX_CRLF = re.compile(r"\r\n")
 REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
-REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.@_-]+?)|((?<=[\s\(\"'])@[\w\.@_-]+?)(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "@" + "<username>" mentions
-REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.@_-]+?\])|((?<=[\s\(\"'])\[~[\w\.@_-]+?\])(?=[\s\)\"'\?!,;:\.$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
+REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\.@_-]+?)|((?<=[\s\(\"'，．])@[\w\.@_-]+?)(?=[\s\)\"'\?!,，;:\.．$])")  # this regex may capture only "@" + "<username>" mentions
+REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\.@_-]+?\])|((?<=[\s\(\"'，．])\[~[\w\.@_-]+?\])(?=[\s\)\"'\?!,，;:\.．$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
 REGEX_GITHUB_ISSUE_LINK = re.compile(r"(\s)(#\d+)(\s)")
 


### PR DESCRIPTION
I think we shouldn't apply any normalization such as full-width -> halfwidth but can try to refine the regex.

![Screenshot from 2022-08-06 17-19-43](https://user-images.githubusercontent.com/1825333/183240954-6499a57e-edbb-41fa-a33e-17942c363b1c.png)

should be 

![Screenshot from 2022-08-06 17-19-08](https://user-images.githubusercontent.com/1825333/183240936-649892c3-ebc2-4db0-bf2a-cd1cdd6c4b40.png)
