### PR TITLE
Capture jira mentions appear at the end of a line

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -228,8 +228,8 @@ JIRA_EMOJI_TO_UNICODE = {
 
 REGEX_CRLF = re.compile(r"\r\n")
 REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
-REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\s\.@_-]+?)|((?<=[\s\(\"'，．])@[\w\s\.@_-]+?)(?=[\s\)\"'\?!,，;:\.．$])")  # this regex may capture only "@" + "<username>" mentions
-REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\s\.@_-]+?\])|((?<=[\s\(\"'，．])\[~[\w\s\.@_-]+?\])(?=[\s\)\"'\?!,，;:\.．$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
+REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\s\.@_-]+?)|((?<=[\s\(\"'，．])@[\w\s\.@_-]+?)($|(?=[\s\)\"'\?!,，;:\.．]))")  # this regex may capture only "@" + "<username>" mentions
+REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\s\.@_-]+?\])|((?<=[\s\(\"'，．])\[~[\w\s\.@_-]+?\])($|(?=[\s\)\"'\?!,，;:\.．]))")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
 REGEX_GITHUB_ISSUE_LINK = re.compile(r"(\s)(#\d+)(\s)")
 


### PR DESCRIPTION
The regex needs to be fixed to properly capture mentions at the end of a line.

e.g.,

https://github.com/mocobeta/migration-test-3/issues/535
![Screenshot from 2022-08-06 17-46-47](https://user-images.githubusercontent.com/1825333/183241961-11b1386b-0e8e-4705-afab-d832213fbf6e.png)

https://github.com/mocobeta/migration-test-3/issues/536#issuecomment-1207175809
![Screenshot from 2022-08-06 17-47-30](https://user-images.githubusercontent.com/1825333/183241983-f4548b65-973c-4460-8e73-d244493faef1.png)

https://github.com/mocobeta/migration-test-3/issues/537#issuecomment-1207175836
![Screenshot from 2022-08-06 17-47-52](https://user-images.githubusercontent.com/1825333/183241996-7c5e9070-c6d4-48c2-b954-e81dd483c87f.png)

Close #113 
