### PR TITLE
Refine regex for mentions parens

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -228,8 +228,8 @@ JIRA_EMOJI_TO_UNICODE = {
 
 REGEX_CRLF = re.compile(r"\r\n")
 REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
-REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\s\.@_-]+?)|((?<=[\s\(\"'，．])@[\w\s\.@_-]+?)(?=[\s\)\"'\?!,，;:\.．$])")  # this regex may capture only "@" + "<username>" mentions
-REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\s\.@_-]+?\])|((?<=[\s\(\"'，．])\[~[\w\s\.@_-]+?\])(?=[\s\)\"'\?!,，;:\.．$])")  # this regex may capture only "[~" + "<username>" + "]" mentions
+REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\s\.@_-]+?)|((?<=[\s\(\"'，．])@[\w\s\.@_-]+?)($|(?=[\s\)\"'\?!,，;:\.．]))")  # this regex may capture only "@" + "<username>" mentions
+REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\s\.@_-]+?\])|((?<=[\s\(\"'，．])\[~[\w\s\.@_-]+?\])($|(?=[\s\)\"'\?!,，;:\.．]))")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
 REGEX_GITHUB_ISSUE_LINK = re.compile(r"(\s)(#\d+)(\s)")
 

--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -228,8 +228,8 @@ JIRA_EMOJI_TO_UNICODE = {
 
 REGEX_CRLF = re.compile(r"\r\n")
 REGEX_JIRA_KEY = re.compile(r"[^/]LUCENE-\d+")
-REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\s\.@_-]+?)|((?<=[\s\(\"'，．])@[\w\s\.@_-]+?)($|(?=[\s\)\"'\?!,，;:\.．]))")  # this regex may capture only "@" + "<username>" mentions
-REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\s\.@_-]+?\])|((?<=[\s\(\"'，．])\[~[\w\s\.@_-]+?\])($|(?=[\s\)\"'\?!,，;:\.．]))")  # this regex may capture only "[~" + "<username>" + "]" mentions
+REGEX_MENTION_ATMARK = re.compile(r"(^@[\w\s\.@_-]+?)|((?<=[\s\({\[\"'，．])@[\w\s\.@_-]+?)($|(?=[\s\)}\]\"'\?!,，;:\.．]))")  # this regex may capture only "@" + "<username>" mentions
+REGEX_MENION_TILDE = re.compile(r"(^\[~[\w\s\.@_-]+?\])|((?<=[\s\({\[\"'，．])\[~[\w\s\.@_-]+?\])($|(?=[\s\)|\]\"'\?!,，;:\.．]))")  # this regex may capture only "[~" + "<username>" + "]" mentions
 REGEX_LINK = re.compile(r"\[([^\]]+)\]\(([^\)]+)\)")
 REGEX_GITHUB_ISSUE_LINK = re.compile(r"(\s)(#\d+)(\s)")
 


### PR DESCRIPTION
Properly capture mentions that follow `{` or `[`.

https://github.com/mocobeta/migration-test-3/issues/540

![Screenshot from 2022-08-06 18-00-39](https://user-images.githubusercontent.com/1825333/183242366-a0c4538e-7151-4308-b12d-ba8c8b60f531.png)

Here, `@link` in `{@link ...}` should be captured (and escaped).

Close #114 