### PR TITLE
Place github issue link first

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -330,7 +330,7 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, int], gh_number_self:
         res = m.group(0)
         gh_number = issue_id_map.get(m.group(1))
         if gh_number and gh_number != gh_number_self:
-            res = f"{m.group(0)} (#{gh_number})"
+            res = f"#{gh_number} ({m.group(0)})"
             # print(res)
         return res
 


### PR DESCRIPTION
Suggested in #124 

Replace `LUCENE-XXXX (#NN)` with `#NN (LUCENE-XXXX)` for linked issues or sub-tasks.

See https://github.com/mocobeta/migration-test-3/issues/544.