### PR TITLE
Drop jira link from linked-issues

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -330,7 +330,7 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, int], gh_number_self:
         res = m.group(0)
         gh_number = issue_id_map.get(m.group(1))
         if gh_number and gh_number != gh_number_self:
-            res = f"#{gh_number} ({m.group(0)})"
+            res = f"#{gh_number}"
             # print(res)
         return res
 


### PR DESCRIPTION
Follow-up of #130.

We use GitHub issue link `#NN` for the first place; then I think there would be no need for creating links to Jira anymore (a fallback link to the original Jira is available in each GitHub issue).

e.g.:
![Screenshot from 2022-08-07 15-34-54](https://user-images.githubusercontent.com/1825333/183278458-7bcc7f77-6a93-4e17-9ea4-5a6bb5456cdb.png)
