### PR TITLE
Replace lucene jira url with github issue number

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -336,6 +336,8 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, int], gh_number_self:
 
     text = re.sub(r"(\s)(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
     text = re.sub(r"(^)(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
+    text = re.sub(r"(\s)https?://issues\.apache\.org/.+/(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
+    text = re.sub(r"(^)https?://issues\.apache\.org/.+/(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
     text = re.sub(r"(\()(LUCENE-\d+)(\))", repl_paren, text)
     text = re.sub(r"(\[)(LUCENE-\d+)(\])(?!\()", repl_bracket, text)
     text = re.sub(r"\[(LUCENE-\d+)\]\(https?[^\)]+LUCENE-\d+\)", repl_md_link, text)


### PR DESCRIPTION
Closes #132.

This tries to capture URL-like strings that points to LUCENE issues and replace the URLs with a GitHub issue mentions `#NN` as we already did for short issue keys `LUCENE-XXXX`; so that readers do not have to fall back to Jira.
```
https?://issues\.apache\.org/jira/.+/LUCENE-\d+
```

For example, 

![Screenshot from 2022-08-07 16-54-33](https://user-images.githubusercontent.com/1825333/183281076-ef92e3f7-98aa-4837-a5f6-83e54f8ce7ea.png)

will be
![Screenshot from 2022-08-07 16-54-58](https://user-images.githubusercontent.com/1825333/183281115-79666329-a78f-4a73-916a-0ff5d1642504.png)
