### PR TITLE
Insert linefeeds before/after a code block

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -7,10 +7,12 @@ from typing import Optional
 
 import jira2markdown
 from jira2markdown.elements import MarkupElements
+from jira2markdown.markup.advanced import Code
 from jira2markdown.markup.lists import UnorderedList, OrderedList
 from jira2markdown.markup.text_effects import BlockQuote, Quote, Monospaced
 from jira2markdown.markup.text_breaks import Ruler
 
+from markup.advanced import TweakedCode
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
 from markup.text_effects import EscapeHtmlTag, TweakedBlockQuote, TweakedQuote, TweakedMonospaced
 from markup.text_breaks import LongRuler
@@ -330,6 +332,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
 
     # convert Jira markup into Markdown with customization
     elements = MarkupElements()
+    elements.replace(Code, TweakedCode)
     elements.replace(UnorderedList, UnorderedTweakedList)
     elements.replace(OrderedList, OrderedTweakedList)
     elements.replace(BlockQuote, TweakedBlockQuote)

--- a/migration/src/markup/advanced.py
+++ b/migration/src/markup/advanced.py
@@ -1,0 +1,34 @@
+from pyparsing import (
+    Combine,
+    FollowedBy,
+    Literal,
+    Optional,
+    ParserElement,
+    ParseResults,
+    SkipTo,
+    Word,
+    alphanums,
+)
+
+from jira2markdown.markup.base import AbstractMarkup
+
+
+class TweakedCode(AbstractMarkup):
+    def action(self, tokens: ParseResults) -> str:
+        lang = tokens.lang or "Java"
+        text = tokens.text.strip("\n")
+        # insert '\n' before and after the code block.
+        return f"\n```{lang}\n{text}\n```\n"
+
+    @property
+    def expr(self) -> ParserElement:
+        return Combine(
+            "{code"
+            + Optional(
+                ":" + Word(alphanums + "#+").setResultsName("lang") + FollowedBy(Literal("}") | Literal("|")),
+            )
+            + ...
+            + "}"
+            + SkipTo("{code}").setResultsName("text")
+            + "{code}",
+        ).setParseAction(self.action)


### PR DESCRIPTION
Close #115 

Line feeds are needed before/after a code block; otherwise, the converted code block is broken in Markdown when the author didn't insert them in the original Jira comments.

e.g.:
https://github.com/mocobeta/forks-migration-test-2/issues/8980#issuecomment-1205891709
![Screenshot from 2022-08-08 20-33-23](https://user-images.githubusercontent.com/1825333/183408971-8574713c-4376-4171-94b1-96382eec6832.png)

should be
https://github.com/mocobeta/migration-test-3/issues/576#issuecomment-1208001512
![Screenshot from 2022-08-08 20-34-19](https://user-images.githubusercontent.com/1825333/183409090-216dc290-136f-4250-8d7f-3da00f3a32e8.png)
