### PR TITLE
Enable GitHub Pages for hosting attachment files.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,7 @@ github:
     issues: true
     projects: false
 
+  ghp_branch:  gh-pages  # for attachments
 
 notifications:
   commits:      commits@lucene.apache.org


### PR DESCRIPTION
#127 

Following https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features, this enables GitHub pages. The document root is `gh-pages` branch (we don't want to place all attachments in `main` branch).