### PR TITLE
use GitHub Pages instad of raw.githubusercontent.com

### DIFF
--- a/migration/.env.example
+++ b/migration/.env.example
@@ -1,6 +1,5 @@
 export GITHUB_PAT=
 export GITHUB_REPO=
-export GITHUB_ATT_REPO="apache/lucene-jira-archive"
-export GITHUB_ATT_BRANCH="attachments"
+export GITHUB_ATT_BASE_URL="https://apache.github.io/lucene-jira-archive/attachments"
 export ATTACHMENTS_DL_DIR=
 export JIRA_PAT=

--- a/migration/README.md
+++ b/migration/README.md
@@ -57,7 +57,7 @@ LUCENE-10502
 ...
 ```
 
-Downloaded attachments should be separately committed to a dedicated branch named `attachments` (or matching the `GITHUB_ATT_BRANCH` env variable) for them.
+Downloaded attachments should be uploaded to a web server or static content hosting service (i.e. GitHub Pages). You also need to set `ATTACHMENTS_BASE_URL` environment variable to correctly point to the attachment files from migrated GitHub isseus.
 
 ### 2. (Optional) Generate Jira -> GitHub account mapping
 


### PR DESCRIPTION
#127 

I moved all attachments files to `gh-pages` branch from `attachments` branch and enabled GitHub Pages for this repo. https://github.com/apache/lucene-jira-archive/pull/139
Now all attachments can be accessed via `https://apache.github.io/lucene-jira-archive/`.

e.g. https://github.com/mocobeta/migration-test-3/issues/594