### PR TITLE
attach type:task label to Sub-tasks

### DIFF
--- a/migration/src/common.py
+++ b/migration/src/common.py
@@ -195,7 +195,8 @@ ISSUE_TYPE_TO_LABEL_MAP = {
     "Improvement": "type:enhancement",
     "Test": "type:test",
     "Wish": "type:enhancement",
-    "Task": "type:task"
+    "Task": "type:task",
+    "Sub-task": "type:task"
 }
 
 


### PR DESCRIPTION
Sub-tasks should have `type:task` label.