### PR TITLE
Escape '>' to avoid wrong quotes in markdown

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -14,7 +14,7 @@ from jira2markdown.markup.text_breaks import Ruler
 
 from markup.advanced import TweakedCode
 from markup.lists import UnorderedTweakedList, OrderedTweakedList
-from markup.text_effects import EscapeHtmlTag, TweakedBlockQuote, TweakedQuote, TweakedMonospaced
+from markup.text_effects import EscapeHtmlTag, EscapeQuoteMD, TweakedBlockQuote, TweakedQuote, TweakedMonospaced
 from markup.text_breaks import LongRuler
 
 
@@ -340,6 +340,7 @@ def convert_text(text: str, att_replace_map: dict[str, str] = {}, account_map: d
     elements.replace(Monospaced, TweakedMonospaced)
     elements.insert_after(Ruler, LongRuler)
     elements.append(EscapeHtmlTag)
+    elements.append(EscapeQuoteMD)
     text = jira2markdown.convert(text, elements=elements)
 
     # convert links to attachments

--- a/migration/src/markup/text_effects.py
+++ b/migration/src/markup/text_effects.py
@@ -7,6 +7,7 @@ from pyparsing import (
     StringStart,
     SkipTo,
     Literal,
+    LineStart,
     LineEnd,
     Combine,
     Literal,
@@ -74,3 +75,14 @@ class EscapeHtmlTag(AbstractMarkup):
     @property
     def expr(self) -> ParserElement:
         return Literal("<").setParseAction(replaceWith("&lt;")) + SkipTo(Literal(">")) + Literal(">").setParseAction(replaceWith("&gt;"))
+
+
+class EscapeQuoteMD(AbstractMarkup):
+    """
+    Escapes '>' at the start of the line that are not a part of any expression grammar
+    """
+
+    @property
+    def expr(self) -> ParserElement:
+        return LineStart() + Literal(">").setParseAction(replaceWith("&gt;"))
+


### PR DESCRIPTION
#93 

`>` should be escaped 1) if it appears at the start of the line, and also 2) is not a part of any expression grammar. It's possible to do such selective escape by tweaking the syntax parser a bit.

e.g.,
https://github.com/mocobeta/forks-migration-test/issues/2321#issuecomment-1197365531
![Screenshot from 2022-08-13 13-09-09](https://user-images.githubusercontent.com/1825333/184467914-78bc6989-ed4e-4154-b97b-851f425d7ce2.png)

should be
https://github.com/mocobeta/migration-test-3/issues/598#issuecomment-1213646156
![Screenshot from 2022-08-13 13-09-59](https://user-images.githubusercontent.com/1825333/184467936-119e2c32-a56f-43eb-9c4f-3046b01202df.png)

Note that this is applied only to plain texts without markups so that it does not affect on code blocks like this: https://github.com/mocobeta/migration-test-3/issues/601.

