### PR TITLE
don't convert Lucene issue urls with query parameters to GitHub issue mentions

### DIFF
--- a/migration/src/jira_util.py
+++ b/migration/src/jira_util.py
@@ -419,8 +419,8 @@ def embed_gh_issue_link(text: str, issue_id_map: dict[str, int], gh_number_self:
 
     text = re.sub(r"(\s)(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
     text = re.sub(r"(^)(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
-    text = re.sub(r"(\s)https?://issues\.apache\.org/.+/(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
-    text = re.sub(r"(^)https?://issues\.apache\.org/.+/(LUCENE-\d+)([\s,;:\?\!\.])", repl_simple, text)
+    text = re.sub(r"(\s)https?://issues\.apache\.org/.+/(LUCENE-\d+)([\s,;:\!\.])", repl_simple, text)
+    text = re.sub(r"(^)https?://issues\.apache\.org/.+/(LUCENE-\d+)([\s,;:\!\.])", repl_simple, text)
     text = re.sub(r"(\()(LUCENE-\d+)(\))", repl_paren, text)
     text = re.sub(r"(\[)(LUCENE-\d+)(\])(?!\()", repl_bracket, text)
     text = re.sub(r"\[(LUCENE-\d+)\]\(https?[^\)]+LUCENE-\d+\)", repl_md_link, text)


### PR DESCRIPTION
Relates to #144.

If Lucene Jira issue URL (`https://issues.apache.org/jira/browse/LUCENE-XXXX`) has query parameters that shouldn't be converted to GitHub issue mentions #NN.

If the URL has query parameters it may be a link to a specific comment (e.g. https://issues.apache.org/jira/browse/LUCENE-9414?focusedCommentId=17142414&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17142414 ). In that case, cross-issue remapping should not be applied.